### PR TITLE
Fix custom_select integration error

### DIFF
--- a/custom_components/hoymiles_cloud/__init__.py
+++ b/custom_components/hoymiles_cloud/__init__.py
@@ -25,7 +25,7 @@ from .hoymiles_api import HoymilesAPI
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.SENSOR, Platform.NUMBER, Platform.SELECT, "custom_select"]
+PLATFORMS = [Platform.SENSOR, Platform.NUMBER, Platform.SELECT]
 
 # Define a helper function to convert mode number to key
 def _get_mode_key_for_num(mode_num):


### PR DESCRIPTION
Fix the "Setup failed for custom_select: Integration not found" error by removing the invalid 'custom_select' platform from the PLATFORMS list.

Fixes #3

Generated with [Claude Code](https://claude.ai/code)