### PR TITLE
Fix API Error 3 (No Permission) for systems without battery

### DIFF
--- a/custom_components/hoymiles_cloud/__init__.py
+++ b/custom_components/hoymiles_cloud/__init__.py
@@ -147,7 +147,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         battery_settings = await api.get_battery_settings(station_id)
                         _LOGGER.debug("Battery settings obtained: %s", "success" if battery_settings else "failed")
                     except Exception as e:
-                        _LOGGER.warning("Failed to get battery settings: %s", e)
+                        _LOGGER.debug("Failed to get battery settings (likely no battery connected): %s", e)
                         # Create default battery settings if they couldn't be retrieved
                         battery_settings = {"data": {"mode": 1, "reserve_soc": 20}}
                     


### PR DESCRIPTION
Handle the case where Hoymiles systems don't have a battery connected by treating API error 3 - No Permission as an expected scenario. The integration now logs this as info/debug instead of error and gracefully falls back to default battery settings, allowing setup to complete successfully.

Changes:
- hoymiles_api.py: Handle API error 3 as INFO instead of ERROR
- hoymiles_api.py: Change fallback warning to DEBUG with context
- __init__.py: Use DEBUG level for no-battery scenarios in coordinator

Fixes #6

Generated with [Claude Code](https://claude.ai/code)