### PR TITLE
Hoymiles redesign + S-Miles Home login diagnosis & scaffolding

### DIFF
--- a/custom_components/hoymiles_cloud/__init__.py
+++ b/custom_components/hoymiles_cloud/__init__.py
@@ -2,6 +2,7 @@
 from copy import deepcopy
 import logging
 from datetime import timedelta
+import time
 from typing import Any
 
 import async_timeout
@@ -15,7 +16,23 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 import voluptuous as vol
 
-from .const import BATTERY_MODE_IDS, DEFAULT_SCAN_INTERVAL, DOMAIN, STORAGE_KEY, STORAGE_VERSION
+from .const import (
+    AUTH_MODE_AUTO,
+    BATTERY_MODE_IDS,
+    CONF_APP_VERSION,
+    CONF_AUTH_MODE,
+    CONF_FETCH_ENERGY_FLOW,
+    CONF_FETCH_EPS_PROFIT,
+    CONF_FETCH_GRID_INDICATORS,
+    DEFAULT_FETCH_ENERGY_FLOW,
+    DEFAULT_FETCH_EPS_PROFIT,
+    DEFAULT_FETCH_GRID_INDICATORS,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_STATIC_REFRESH_INTERVAL,
+    DOMAIN,
+    STORAGE_KEY,
+    STORAGE_VERSION,
+)
 from .data import (
     add_schedule_entry,
     battery_settings_readable,
@@ -28,10 +45,19 @@ from .data import (
     update_schedule_editor_draft,
 )
 from .hoymiles_api import HoymilesAPI
+from .models import AIStatus, DeviceInventory, EPSProfit, EnergyFlow, FirmwareStatus, SettingRules, StationData
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.SENSOR, Platform.NUMBER, Platform.SELECT, Platform.TEXT, Platform.BUTTON]
+PLATFORMS = [
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.TEXT,
+    Platform.BUTTON,
+    Platform.SWITCH,
+]
 
 SERVICE_SET_BATTERY_MODE = "set_battery_mode"
 SERVICE_SET_BATTERY_MODE_SETTINGS = "set_battery_mode_settings"
@@ -350,9 +376,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    auth_mode = entry.data.get(CONF_AUTH_MODE, AUTH_MODE_AUTO)
+    app_version = entry.data.get(CONF_APP_VERSION)
+    fetch_grid_indicators = entry.options.get(
+        CONF_FETCH_GRID_INDICATORS,
+        DEFAULT_FETCH_GRID_INDICATORS,
+    )
+    fetch_energy_flow = entry.options.get(
+        CONF_FETCH_ENERGY_FLOW,
+        DEFAULT_FETCH_ENERGY_FLOW,
+    )
+    fetch_eps_profit = entry.options.get(
+        CONF_FETCH_EPS_PROFIT,
+        DEFAULT_FETCH_EPS_PROFIT,
+    )
 
     session = async_get_clientsession(hass)
     api = HoymilesAPI(session, username, password)
+    api.configure_auth(auth_mode=auth_mode, app_version=app_version)
     store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
     stored_data = await store.async_load() or {}
 
@@ -379,6 +420,88 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if _ensure_station_storage(stored_data, stations):
         await store.async_save(stored_data)
 
+    static_station_cache: dict[str, dict[str, Any]] = {}
+    static_station_cache_at: dict[str, float] = {}
+
+    async def _async_fetch_static_station_payload(station_id: str) -> dict[str, Any]:
+        """Fetch slower-changing station metadata and device inventory."""
+        try:
+            station_info = await api.get_station_details(station_id)
+        except Exception as err:
+            _LOGGER.warning("Failed to get station details for station %s: %s", station_id, err)
+            station_info = {}
+        if station_info.get("name"):
+            stations[station_id] = str(station_info["name"])
+
+        try:
+            setting_rules = await api.get_setting_rules(station_id)
+        except Exception as err:
+            _LOGGER.warning("Failed to get setting rules for station %s: %s", station_id, err)
+            setting_rules = {}
+
+        try:
+            dtus = await api.get_dtus(station_id)
+        except Exception as err:
+            _LOGGER.warning("Failed to get DTUs for station %s: %s", station_id, err)
+            dtus = []
+
+        try:
+            inverters = await api.get_inverters(station_id)
+        except Exception as err:
+            _LOGGER.warning("Failed to get inverters for station %s: %s", station_id, err)
+            inverters = []
+
+        try:
+            batteries = await api.get_batteries(station_id)
+        except Exception as err:
+            _LOGGER.warning("Failed to get batteries for station %s: %s", station_id, err)
+            batteries = []
+
+        try:
+            meters = await api.get_meters(station_id)
+        except Exception as err:
+            _LOGGER.warning("Failed to get meters for station %s: %s", station_id, err)
+            meters = []
+
+        try:
+            microinverters = await api.get_microinverters_by_stations(station_id)
+        except Exception as err:
+            _LOGGER.warning("Failed to get microinverter details for station %s: %s", station_id, err)
+            microinverters = {}
+
+        try:
+            eps_settings = await api.get_eps_settings(station_id)
+        except Exception as err:
+            _LOGGER.warning("Failed to get EPS settings for station %s: %s", station_id, err)
+            eps_settings = {}
+
+        try:
+            ai_status = await api.get_ai_status(station_id)
+        except Exception as err:
+            _LOGGER.warning("Failed to get AI status for station %s: %s", station_id, err)
+            ai_status = {}
+
+        try:
+            firmware = await api.get_firmware_status(station_id)
+        except Exception as err:
+            _LOGGER.warning("Failed to get firmware status for station %s: %s", station_id, err)
+            firmware = {}
+
+        return {
+            "station_info": station_info,
+            "setting_rules": SettingRules(setting_rules).as_dict(),
+            "devices": DeviceInventory(
+                dtus=dtus,
+                inverters=inverters,
+                batteries=batteries,
+                meters=meters,
+                microinverters=microinverters,
+            ).as_dict(),
+            "eps_settings": eps_settings,
+            "ai_status": AIStatus(ai_status).as_dict(),
+            "firmware": FirmwareStatus(firmware).as_dict(),
+        }
+
     async def async_update_data():
         """Fetch data from API."""
         try:
@@ -394,17 +517,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 should_save_store = False
 
                 for station_id in stations:
-                    real_time_data = await api.get_real_time_data(station_id)
+                    now = time.monotonic()
+                    if (
+                        station_id not in static_station_cache
+                        or now - static_station_cache_at.get(station_id, 0) >= DEFAULT_STATIC_REFRESH_INTERVAL
+                    ):
+                        static_station_cache[station_id] = await _async_fetch_static_station_payload(station_id)
+                        static_station_cache_at[station_id] = now
+                    static_payload = static_station_cache.get(station_id, {})
 
-                    try:
-                        microinverters_data = await api.get_microinverters_by_stations(station_id)
-                    except Exception as err:
-                        _LOGGER.warning(
-                            "Failed to get microinverter details for station %s: %s",
-                            station_id,
-                            err,
-                        )
-                        microinverters_data = {}
+                    real_time_data = await api.get_real_time_data(station_id)
 
                     try:
                         pv_indicators = await api.get_pv_indicators(station_id)
@@ -416,6 +538,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         )
                         pv_indicators = {}
 
+                    if fetch_grid_indicators:
+                        try:
+                            grid_indicators = await api.get_grid_indicators(station_id)
+                        except Exception as err:
+                            _LOGGER.warning(
+                                "Failed to get grid indicators for station %s: %s",
+                                station_id,
+                                err,
+                            )
+                            grid_indicators = {}
+                    else:
+                        grid_indicators = {}
+
+                    try:
+                        load_indicators = await api.get_load_indicators(station_id)
+                    except Exception as err:
+                        _LOGGER.warning(
+                            "Failed to get load indicators for station %s: %s",
+                            station_id,
+                            err,
+                        )
+                        load_indicators = {}
+
                     try:
                         battery_settings = await api.get_battery_settings(station_id)
                     except Exception as err:
@@ -426,6 +571,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         )
                         battery_settings = {}
 
+                    try:
+                        relay_settings = await api.get_relay_settings(station_id)
+                    except Exception as err:
+                        _LOGGER.warning(
+                            "Failed to get relay settings for station %s: %s",
+                            station_id,
+                            err,
+                        )
+                        relay_settings = {}
+
+                    if fetch_energy_flow:
+                        try:
+                            energy_flow = await api.get_energy_flow(station_id)
+                        except Exception as err:
+                            _LOGGER.warning(
+                                "Failed to get energy flow for station %s: %s",
+                                station_id,
+                                err,
+                            )
+                            energy_flow = {}
+                    else:
+                        energy_flow = {}
+
+                    if fetch_eps_profit:
+                        try:
+                            eps_profit = await api.get_eps_profit(station_id)
+                        except Exception as err:
+                            _LOGGER.warning(
+                                "Failed to get EPS profit for station %s: %s",
+                                station_id,
+                                err,
+                            )
+                            eps_profit = {}
+                    else:
+                        eps_profit = {}
+
                     station_stored_data = stored_data["stations"].setdefault(station_id, {})
                     enhanced_battery_settings, station_changed = _enhance_battery_settings(
                         battery_settings,
@@ -433,22 +614,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     )
                     should_save_store = should_save_store or station_changed
 
-                    refreshed[station_id] = {
-                        "real_time_data": real_time_data,
-                        "microinverters_data": microinverters_data,
-                        "pv_indicators": pv_indicators,
-                        "battery_settings": enhanced_battery_settings,
-                        "schedule_editor": build_schedule_editor_state(
+                    refreshed[station_id] = StationData(
+                        station_info=static_payload.get("station_info", {}),
+                        real_time_data=real_time_data,
+                        energy_flow=EnergyFlow(energy_flow).as_dict(),
+                        pv_indicators=pv_indicators,
+                        grid_indicators=grid_indicators,
+                        load_indicators=load_indicators,
+                        battery_settings=enhanced_battery_settings,
+                        relay_settings=relay_settings,
+                        eps_settings=static_payload.get("eps_settings", {}),
+                        eps_profit=EPSProfit(eps_profit).as_dict(),
+                        ai_status=static_payload.get("ai_status", {}),
+                        setting_rules=static_payload.get("setting_rules", {}),
+                        devices=static_payload.get("devices", {}),
+                        firmware=static_payload.get("firmware", {}),
+                        schedule_editor=build_schedule_editor_state(
                             enhanced_battery_settings,
                             station_stored_data,
                         ),
-                        "capabilities": build_station_capabilities(
+                        capabilities=build_station_capabilities(
                             real_time_data=real_time_data,
                             pv_indicators=pv_indicators,
                             battery_settings=enhanced_battery_settings,
-                            microinverters_data=microinverters_data,
+                            microinverters_data=static_payload.get("devices", {}).get("microinverters", {}),
+                            grid_indicators=grid_indicators,
+                            load_indicators=load_indicators,
+                            energy_flow=energy_flow,
+                            relay_settings=relay_settings,
+                            setting_rules=static_payload.get("setting_rules", {}),
+                            devices=static_payload.get("devices", {}),
+                            eps_settings=static_payload.get("eps_settings", {}),
+                            eps_profit=eps_profit,
+                            ai_status=static_payload.get("ai_status", {}),
+                            firmware=static_payload.get("firmware", {}),
+                            station_info=static_payload.get("station_info", {}),
                         ),
-                    }
+                    ).as_dict()
 
                 if should_save_store:
                     await store.async_save(stored_data)
@@ -477,6 +679,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "store": store,
         "stored_data": stored_data,
         "entry": entry,
+        "static_station_cache": static_station_cache,
+        "fetch_grid_indicators": fetch_grid_indicators,
+        "fetch_energy_flow": fetch_energy_flow,
+        "fetch_eps_profit": fetch_eps_profit,
     }
 
     def async_refresh_local_editor_state(station_id: str | None = None) -> None:

--- a/custom_components/hoymiles_cloud/binary_sensor.py
+++ b/custom_components/hoymiles_cloud/binary_sensor.py
@@ -1,0 +1,156 @@
+"""Binary sensor platform for Hoymiles Cloud integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
+
+from .const import DOMAIN
+from .device import build_primary_battery_device_info, build_station_device_info
+
+
+def get_station_data(coordinator: DataUpdateCoordinator, station_id: str) -> dict[str, Any]:
+    """Return one station payload."""
+    return coordinator.data.get(station_id, {}) if coordinator.data else {}
+
+
+def get_reflux_data(station_data: dict[str, Any]) -> dict[str, Any]:
+    """Return the reflux payload."""
+    return station_data.get("real_time_data", {}).get("reflux_station_data", {})
+
+
+def safe_float(value: Any) -> float | None:
+    """Return a float if the value is numeric."""
+    try:
+        if value in (None, "", "-"):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+@dataclass
+class HoymilesBinarySensorDescription(BinarySensorEntityDescription):
+    """Declarative binary sensor definition."""
+
+    value_fn: Callable[[dict[str, Any]], bool] | None = None
+    exists_fn: Callable[[dict[str, Any]], bool] | None = None
+    device_info_fn: Callable[[str, str, dict[str, Any]], dict[str, Any]] | None = None
+
+
+DESCRIPTIONS: list[HoymilesBinarySensorDescription] = [
+    HoymilesBinarySensorDescription(
+        key="battery_charging",
+        name="Battery Charging",
+        device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+        value_fn=lambda data: (safe_float(get_reflux_data(data).get("bms_power")) or 0.0) > 0,
+        exists_fn=lambda data: bool(data.get("capabilities", {}).get("battery_telemetry")),
+        device_info_fn=lambda sid, name, data: build_primary_battery_device_info(sid, name, data),
+    ),
+    HoymilesBinarySensorDescription(
+        key="grid_connected",
+        name="Grid Connected",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        value_fn=lambda data: bool(get_reflux_data(data)),
+        exists_fn=lambda data: True,
+        device_info_fn=lambda sid, name, data: build_station_device_info(sid, name, data.get("station_info")),
+    ),
+    HoymilesBinarySensorDescription(
+        key="firmware_update_available",
+        name="Firmware Update Available",
+        device_class=BinarySensorDeviceClass.UPDATE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: int(data.get("firmware", {}).get("upgrade", 0) or 0) > 0,
+        exists_fn=lambda data: bool(data.get("capabilities", {}).get("firmware_available")),
+        device_info_fn=lambda sid, name, data: build_station_device_info(sid, name, data.get("station_info")),
+    ),
+    HoymilesBinarySensorDescription(
+        key="ai_mode_active",
+        name="AI Mode Active",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get("ai_status", {}).get("ai") == 1,
+        exists_fn=lambda data: bool(data.get("capabilities", {}).get("ai_available")),
+        device_info_fn=lambda sid, name, data: build_station_device_info(sid, name, data.get("station_info")),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Hoymiles Cloud binary sensors."""
+    runtime_data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = runtime_data["coordinator"]
+    stations = runtime_data["stations"]
+
+    entities: list[BinarySensorEntity] = []
+    for station_id, station_name in stations.items():
+        station_data = get_station_data(coordinator, station_id)
+        for description in DESCRIPTIONS:
+            if description.exists_fn and not description.exists_fn(station_data):
+                continue
+            entities.append(
+                HoymilesBinarySensor(
+                    coordinator,
+                    station_id,
+                    station_name,
+                    description,
+                )
+            )
+
+    async_add_entities(entities)
+
+
+class HoymilesBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Coordinator-backed Hoymiles binary sensor."""
+
+    entity_description: HoymilesBinarySensorDescription
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        station_id: str,
+        station_name: str,
+        description: HoymilesBinarySensorDescription,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+        self._station_id = station_id
+        self.entity_description = description
+        station_data = get_station_data(coordinator, station_id)
+        self._attr_unique_id = f"{DOMAIN}_{station_id}_{description.key}"
+        self._attr_name = f"{station_name} {description.name}"
+        self._attr_device_info = description.device_info_fn(station_id, station_name, station_data)
+
+    def _get_station_data(self) -> dict[str, Any]:
+        """Return the current station payload."""
+        return get_station_data(self.coordinator, self._station_id)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the binary sensor is on."""
+        if not self.entity_description.value_fn:
+            return None
+        return bool(self.entity_description.value_fn(self._get_station_data()))
+
+    @property
+    def available(self) -> bool:
+        """Return whether the entity is available."""
+        if not self.coordinator.last_update_success:
+            return False
+        if self.entity_description.exists_fn:
+            return self.entity_description.exists_fn(self._get_station_data())
+        return True

--- a/custom_components/hoymiles_cloud/config_flow.py
+++ b/custom_components/hoymiles_cloud/config_flow.py
@@ -1,30 +1,54 @@
 """Config flow for Hoymiles Cloud integration."""
+
+from __future__ import annotations
+
 import logging
-from typing import Dict, Optional
+from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import (
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    CONF_SCAN_INTERVAL,
-)
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .auth import AUTH_ERROR_NO_ACCESSIBLE_STATIONS, auth_error_to_config_error
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import (
+    AUTH_MODE_AUTO,
+    AUTH_MODE_OPTIONS,
+    CONF_APP_VERSION,
+    CONF_AUTH_MODE,
+    CONF_FETCH_ENERGY_FLOW,
+    CONF_FETCH_EPS_PROFIT,
+    CONF_FETCH_GRID_INDICATORS,
+    DEFAULT_FETCH_ENERGY_FLOW,
+    DEFAULT_FETCH_EPS_PROFIT,
+    DEFAULT_FETCH_GRID_INDICATORS,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
 from .hoymiles_api import HoymilesAPI
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_USERNAME): str,
-        vol.Required(CONF_PASSWORD): str,
-    }
-)
+
+def _build_user_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
+    """Return the config-flow schema for user credentials."""
+    defaults = defaults or {}
+    return vol.Schema(
+        {
+            vol.Required(CONF_USERNAME, default=defaults.get(CONF_USERNAME, "")): str,
+            vol.Required(CONF_PASSWORD, default=defaults.get(CONF_PASSWORD, "")): str,
+            vol.Required(
+                CONF_AUTH_MODE,
+                default=defaults.get(CONF_AUTH_MODE, AUTH_MODE_AUTO),
+            ): vol.In(AUTH_MODE_OPTIONS),
+            vol.Optional(
+                CONF_APP_VERSION,
+                default=defaults.get(CONF_APP_VERSION, ""),
+            ): str,
+        }
+    )
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -32,92 +56,119 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def __init__(self) -> None:
+        """Initialize the Hoymiles config flow."""
+        self._pending_entry_data: dict[str, Any] | None = None
+        self._pending_station_names: list[str] = []
+        self._pending_username: str | None = None
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
 
-    async def async_step_user(
-        self, user_input: Optional[Dict[str, Any]] = None
-    ) -> FlowResult:
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the initial step."""
-        errors: Dict[str, str] = {}
+        errors: dict[str, str] = {}
+        schema = _build_user_schema(user_input)
+
+        if user_input is None:
+            return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+        username = user_input[CONF_USERNAME]
+        password = user_input[CONF_PASSWORD]
+        auth_mode = user_input.get(CONF_AUTH_MODE, AUTH_MODE_AUTO)
+        app_version = user_input.get(CONF_APP_VERSION, "").strip() or None
+
+        session = async_get_clientsession(self.hass)
+        api = HoymilesAPI(session, username, password)
+        api.configure_auth(auth_mode=auth_mode, app_version=app_version)
+
+        try:
+            authenticated = await api.authenticate()
+            if not authenticated:
+                _LOGGER.error(
+                    "Hoymiles authentication rejected via %s: %s - %s (%s)",
+                    api.last_auth_attempt,
+                    api.last_auth_status,
+                    api.last_auth_message,
+                    api.last_auth_attempt_summary,
+                )
+                errors["base"] = auth_error_to_config_error(api.last_auth_error_key)
+                return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+            stations = await api.get_stations()
+            if not stations:
+                errors["base"] = AUTH_ERROR_NO_ACCESSIBLE_STATIONS
+                return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+            station_metadata: dict[str, dict[str, Any]] = {}
+            for station_id, station_name in stations.items():
+                try:
+                    details = await api.get_station_details(station_id)
+                except Exception as err:
+                    _LOGGER.debug("Failed to fetch station details during config flow: %s", err)
+                    details = {}
+                station_metadata[station_id] = {
+                    "name": details.get("name") or station_name,
+                    "timezone": details.get("timezone") or details.get("tz_name"),
+                    "classify": details.get("classify"),
+                }
+
+            self._pending_entry_data = {
+                CONF_USERNAME: username,
+                CONF_PASSWORD: password,
+                CONF_AUTH_MODE: auth_mode,
+                "station_metadata": station_metadata,
+            }
+            if app_version:
+                self._pending_entry_data[CONF_APP_VERSION] = app_version
+            self._pending_station_names = [item["name"] for item in station_metadata.values()]
+            self._pending_username = username
+            return await self.async_step_confirm()
+
+        except Exception as err:
+            _LOGGER.error("Error connecting to Hoymiles API: %s", err)
+            errors["base"] = "cannot_connect"
+            return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    async def async_step_confirm(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Confirm the discovered stations before creating the entry."""
+        if self._pending_entry_data is None or self._pending_username is None:
+            return await self.async_step_user()
 
         if user_input is not None:
-            username = user_input[CONF_USERNAME]
-            password = user_input[CONF_PASSWORD]
-
-            session = async_get_clientsession(self.hass)
-            api = HoymilesAPI(session, username, password)
-
-            try:
-                # Test authentication
-                authenticated = await api.authenticate()
-                if not authenticated:
-                    _LOGGER.error(
-                        "Hoymiles authentication rejected via %s: %s - %s (%s)",
-                        api.last_auth_attempt,
-                        api.last_auth_status,
-                        api.last_auth_message,
-                        api.last_auth_attempt_summary,
-                    )
-                    errors["base"] = auth_error_to_config_error(api.last_auth_error_key)
-                    return self.async_show_form(
-                        step_id="user",
-                        data_schema=STEP_USER_DATA_SCHEMA,
-                        errors=errors,
-                    )
-
-                user = await api.get_current_user()
-                if not user:
-                    _LOGGER.warning(
-                        "Hoymiles auth succeeded for %s but user profile lookup returned empty data",
-                        username,
-                    )
-
-                # Test getting stations
-                stations = await api.get_stations()
-                if not stations:
-                    errors["base"] = AUTH_ERROR_NO_ACCESSIBLE_STATIONS
-                    return self.async_show_form(
-                        step_id="user",
-                        data_schema=STEP_USER_DATA_SCHEMA,
-                        errors=errors,
-                    )
-
-                # Check if already configured with this username
-                await self.async_set_unique_id(username)
-                self._abort_if_unique_id_configured()
-
-                return self.async_create_entry(
-                    title=username,
-                    data={
-                        CONF_USERNAME: username,
-                        CONF_PASSWORD: password,
-                    },
-                    options={
-                        CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
-                    },
-                )
-
-            except Exception as e:
-                _LOGGER.error("Error connecting to Hoymiles API: %s", e)
-                errors["base"] = "cannot_connect"
+            await self.async_set_unique_id(self._pending_username)
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(
+                title=self._pending_username,
+                data=self._pending_entry_data,
+                options={
+                    CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+                    CONF_FETCH_GRID_INDICATORS: DEFAULT_FETCH_GRID_INDICATORS,
+                    CONF_FETCH_ENERGY_FLOW: DEFAULT_FETCH_ENERGY_FLOW,
+                    CONF_FETCH_EPS_PROFIT: DEFAULT_FETCH_EPS_PROFIT,
+                },
+            )
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "stations": ", ".join(self._pending_station_names),
+            },
         )
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for Hoymiles Cloud."""
 
-    def __init__(self, config_entry):
+    def __init__(self, config_entry) -> None:
         """Initialize options flow."""
         self.config_entry = config_entry
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Manage the options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
@@ -129,9 +180,31 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Required(
                         CONF_SCAN_INTERVAL,
                         default=self.config_entry.options.get(
-                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                            CONF_SCAN_INTERVAL,
+                            DEFAULT_SCAN_INTERVAL,
                         ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=30, max=3600)),
+                    vol.Required(
+                        CONF_FETCH_GRID_INDICATORS,
+                        default=self.config_entry.options.get(
+                            CONF_FETCH_GRID_INDICATORS,
+                            DEFAULT_FETCH_GRID_INDICATORS,
+                        ),
+                    ): bool,
+                    vol.Required(
+                        CONF_FETCH_ENERGY_FLOW,
+                        default=self.config_entry.options.get(
+                            CONF_FETCH_ENERGY_FLOW,
+                            DEFAULT_FETCH_ENERGY_FLOW,
+                        ),
+                    ): bool,
+                    vol.Required(
+                        CONF_FETCH_EPS_PROFIT,
+                        default=self.config_entry.options.get(
+                            CONF_FETCH_EPS_PROFIT,
+                            DEFAULT_FETCH_EPS_PROFIT,
+                        ),
+                    ): bool,
                 }
             ),
-        ) 
+        )

--- a/custom_components/hoymiles_cloud/config_flow.py
+++ b/custom_components/hoymiles_cloud/config_flow.py
@@ -166,7 +166,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
+        self._config_entry = config_entry
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Manage the options."""

--- a/custom_components/hoymiles_cloud/const.py
+++ b/custom_components/hoymiles_cloud/const.py
@@ -6,20 +6,47 @@ DOMAIN = "hoymiles_cloud"
 STORAGE_VERSION = 1
 STORAGE_KEY = f"{DOMAIN}_data"
 
-# API Constants
+# API base URLs
 API_BASE_URL = "https://neapi.hoymiles.com"
+API_EU_BASE_URL = "https://euapi.hoymiles.com"
+API_STREAM_BASE_URL = "https://eurt.hoymiles.com"
+
+# Authentication endpoints
 API_AUTH_URL = f"{API_BASE_URL}/iam/pub/0/auth/login"
 API_AUTH_PRE_INSP_URL = f"{API_BASE_URL}/iam/pub/3/auth/pre-insp"
 API_AUTH_V3_URL = f"{API_BASE_URL}/iam/pub/3/auth/login"
 API_USER_ME_URL = f"{API_BASE_URL}/iam/api/1/user/me"
+
+# Station and device endpoints
 API_STATIONS_URL = f"{API_BASE_URL}/pvm/api/0/station/select_by_page"
-API_REAL_TIME_DATA_URL = f"{API_BASE_URL}/pvm-data/api/0/station/data/count_station_real_data" 
+API_STATION_DETAILS_URL = f"{API_BASE_URL}/pvm/api/0/station/find"
+API_STATION_SETTING_RULE_URL = f"{API_BASE_URL}/pvm/api/0/station/setting_rule"
+API_STATION_GET_SD_URI_URL = f"{API_BASE_URL}/pvm/api/0/station/get_sd_uri"
+API_STATION_USER_SETTING_URL = f"{API_BASE_URL}/pvm/api/0/station/setting/get_user_setting"
+API_STATION_PRICE_URL = f"{API_BASE_URL}/pvm/api/0/station/price/find"
+API_STATION_BATTERY_CONFIG_URL = f"{API_BASE_URL}/pvm/api/0/station/setting/battery_config"
 API_MICROINVERTERS_URL = f"{API_BASE_URL}/pvm/api/0/dev/micro/select_by_station"
 API_MICRO_DETAIL_URL = f"{API_BASE_URL}/pvm/api/0/dev/micro/find"
-API_PV_INDICATORS_URL = f"{API_BASE_URL}/pvm-data/api/0/indicators/data/select_real_indicators_data"
+API_DTUS_URL = f"{API_BASE_URL}/pvm/api/0/dev/dtu/select_by_station"
+API_INVERTERS_URL = f"{API_BASE_URL}/pvm/api/0/dev/inverter/select_by_station"
+API_BATTERIES_URL = f"{API_BASE_URL}/pvm/api/0/dev/battery/select_by_station"
+API_METERS_URL = f"{API_BASE_URL}/pvm/api/0/dev/meter/select_by_station"
+
+# Telemetry endpoints
+API_REAL_TIME_DATA_URL = f"{API_BASE_URL}/pvm-data/api/0/station/data/count_station_real_data"
+API_ENERGY_FLOW_STATS_URL = f"{API_BASE_URL}/pvm-data/api/0/station/data_fd/stat_g_a"
+API_INDICATORS_URL = f"{API_BASE_URL}/pvm-data/api/0/indicators/data/select_real_indicators_data"
+
+# Battery / relay control endpoints
 API_BATTERY_SETTINGS_READ_URL = f"{API_BASE_URL}/pvm-ctl/api/0/dev/setting/read"
 API_BATTERY_SETTINGS_WRITE_URL = f"{API_BASE_URL}/pvm-ctl/api/0/dev/setting/write"
 API_BATTERY_SETTINGS_STATUS_URL = f"{API_BASE_URL}/pvm-ctl/api/0/dev/setting/status"
+
+# Ancillary endpoints
+API_EPS_SETTINGS_URL = f"{API_BASE_URL}/eps/api/0/setting/g_a"
+API_EPS_PROFIT_URL = f"{API_BASE_URL}/eps/api/0/record/stat_a"
+API_AI_STATUS_URL = f"{API_BASE_URL}/pvm-ai/api/0/station/sar_g_c"
+API_FIRMWARE_STATUS_URL = f"{API_BASE_URL}/pvm/api/0/upgrade/compare"
 
 # Authentication modes / client profiles
 AUTH_MODE_AUTO = "auto"
@@ -70,11 +97,13 @@ AUTH_MODE_OPTIONS = {
     AUTH_MODE_LEGACY_V0: "Legacy v0",
 }
 
-# Battery Modes
+# Battery modes
 BATTERY_MODE_SELF_CONSUMPTION = 1
 BATTERY_MODE_ECONOMY = 2
 BATTERY_MODE_BACKUP = 3
 BATTERY_MODE_OFF_GRID = 4
+BATTERY_MODE_SELF_CONSUMPTION_MAX_POWER = 5
+BATTERY_MODE_BACKUP_MAX_POWER = 6
 BATTERY_MODE_PEAK_SHAVING = 7
 BATTERY_MODE_TIME_OF_USE = 8
 
@@ -83,6 +112,8 @@ BATTERY_MODE_IDS = (
     BATTERY_MODE_ECONOMY,
     BATTERY_MODE_BACKUP,
     BATTERY_MODE_OFF_GRID,
+    BATTERY_MODE_SELF_CONSUMPTION_MAX_POWER,
+    BATTERY_MODE_BACKUP_MAX_POWER,
     BATTERY_MODE_PEAK_SHAVING,
     BATTERY_MODE_TIME_OF_USE,
 )
@@ -92,38 +123,71 @@ BATTERY_SCHEDULE_MODE_IDS = (
     BATTERY_MODE_TIME_OF_USE,
 )
 
+BATTERY_POWER_LIMIT_MODE_IDS = (
+    BATTERY_MODE_SELF_CONSUMPTION_MAX_POWER,
+    BATTERY_MODE_BACKUP_MAX_POWER,
+)
+
 BATTERY_MODES = {
     BATTERY_MODE_SELF_CONSUMPTION: "Self-Consumption Mode",
     BATTERY_MODE_ECONOMY: "Economy Mode",
     BATTERY_MODE_BACKUP: "Backup Mode",
     BATTERY_MODE_OFF_GRID: "Off-Grid Mode",
+    BATTERY_MODE_SELF_CONSUMPTION_MAX_POWER: "Self-Consumption + Max Power Mode",
+    BATTERY_MODE_BACKUP_MAX_POWER: "Backup + Max Power Mode",
     BATTERY_MODE_PEAK_SHAVING: "Peak Shaving Mode",
     BATTERY_MODE_TIME_OF_USE: "Time of Use Mode",
 }
 
-# Default settings
+# Action IDs
+BATTERY_SETTINGS_ACTION_ID = 1013
+RELAY_SETTINGS_ACTION_ID = 1014
+INVERTER_CONFIG_ACTION_ID = 1030
+
+# Async command status codes
+BATTERY_SETTINGS_STATUS_RUNNING = 2
+BATTERY_SETTINGS_STATUS_SUCCESS = 0
+
+# Indicator types
+INDICATOR_TYPE_LOAD = 1
+INDICATOR_TYPE_GRID = 2
+INDICATOR_TYPE_PV = 4
+INDICATOR_TYPE_METER_ES = 5
+
+# Energy-flow stats types
+ENERGY_FLOW_STAT_TYPE_OVERVIEW = 1
+ENERGY_FLOW_STAT_TYPE_BATTERY = 4
+ENERGY_FLOW_STAT_TYPE_GRID = 5
+ENERGY_FLOW_STAT_TYPE_FULL = 6
+
+# Meter locations
+METER_LOCATION_GRID = 2
+METER_LOCATION_BATTERY = 4
+METER_LOCATION_NAMES = {
+    METER_LOCATION_GRID: "Grid Meter",
+    METER_LOCATION_BATTERY: "Battery Meter",
+}
+
+# Defaults
 DEFAULT_SCAN_INTERVAL = 60  # seconds
+DEFAULT_STATIC_REFRESH_INTERVAL = 300  # seconds
+DEFAULT_FETCH_GRID_INDICATORS = True
+DEFAULT_FETCH_ENERGY_FLOW = True
+DEFAULT_FETCH_EPS_PROFIT = True
 
 # Configuration
 CONF_STATION_ID = "station_id"
 CONF_AUTH_MODE = "auth_mode"
 CONF_APP_VERSION = "app_version"
+CONF_FETCH_GRID_INDICATORS = "fetch_grid_indicators"
+CONF_FETCH_ENERGY_FLOW = "fetch_energy_flow"
+CONF_FETCH_EPS_PROFIT = "fetch_eps_profit"
 
-# Sensor types
-SENSOR_TYPE_POWER = "power"
-SENSOR_TYPE_ENERGY = "energy"
-SENSOR_TYPE_SOC = "soc"
-SENSOR_TYPE_GRID = "grid"
-SENSOR_TYPE_LOAD = "load"
-
-SETTING_TYPE_MODE = "mode"
-SETTING_TYPE_RESERVE_SOC = "reserve_soc"
-
-# Entity category
+# Entity categories
 ENTITY_CATEGORY_DIAGNOSTIC = "diagnostic"
 ENTITY_CATEGORY_CONFIG = "config"
 
 # Units of measurement
 POWER_WATT = "W"
 ENERGY_WATT_HOUR = "Wh"
-PERCENTAGE = "%" 
+PERCENTAGE = "%"

--- a/custom_components/hoymiles_cloud/const.py
+++ b/custom_components/hoymiles_cloud/const.py
@@ -11,10 +11,15 @@ API_BASE_URL = "https://neapi.hoymiles.com"
 API_EU_BASE_URL = "https://euapi.hoymiles.com"
 API_STREAM_BASE_URL = "https://eurt.hoymiles.com"
 
-# Authentication endpoints
-API_AUTH_URL = f"{API_BASE_URL}/iam/pub/0/auth/login"
-API_AUTH_PRE_INSP_URL = f"{API_BASE_URL}/iam/pub/3/auth/pre-insp"
-API_AUTH_V3_URL = f"{API_BASE_URL}/iam/pub/3/auth/login"
+# Authentication endpoint paths (joined with a profile-specific base URL)
+AUTH_PATH_LOGIN_V0 = "/iam/pub/0/auth/login"
+AUTH_PATH_PRE_INSP_V3 = "/iam/pub/3/auth/pre-insp"
+AUTH_PATH_LOGIN_V3 = "/iam/pub/3/auth/login"
+
+# Authentication endpoints (default neapi host; kept for backwards compatibility)
+API_AUTH_URL = f"{API_BASE_URL}{AUTH_PATH_LOGIN_V0}"
+API_AUTH_PRE_INSP_URL = f"{API_BASE_URL}{AUTH_PATH_PRE_INSP_V3}"
+API_AUTH_V3_URL = f"{API_BASE_URL}{AUTH_PATH_LOGIN_V3}"
 API_USER_ME_URL = f"{API_BASE_URL}/iam/api/1/user/me"
 
 # Station and device endpoints
@@ -70,16 +75,25 @@ AUTH_PROFILE_DEFAULTS = {
         "user_agent": DEFAULT_WEB_USER_AGENT,
         "app_version": None,
         "x_client_type": None,
+        "base_url": API_BASE_URL,
     },
     CLIENT_PROFILE_INSTALLER: {
         "user_agent": DEFAULT_INSTALLER_USER_AGENT,
         "app_version": DEFAULT_INSTALLER_APP_VERSION,
         "x_client_type": "mobile",
+        "base_url": API_BASE_URL,
     },
     CLIENT_PROFILE_HOME: {
         "user_agent": DEFAULT_HOME_USER_AGENT,
         "app_version": DEFAULT_HOME_APP_VERSION,
         "x_client_type": "mobile",
+        # TODO: S-Miles Home consumer backend. Consumer "S-Miles Home" /
+        # "S-Miles Enduser" accounts (e.g. MS-A2 balcony storage) live on a
+        # different Hoymiles backend than neapi.hoymiles.com. Once a sanitized
+        # network trace of the S-Miles Home mobile app login is available, set
+        # this to the real host (and adjust headers/request body as needed).
+        # See GitHub issue #30.
+        "base_url": None,
     },
 }
 
@@ -93,7 +107,7 @@ AUTH_MODE_OPTIONS = {
     AUTH_MODE_AUTO: "Auto-detect",
     AUTH_MODE_WEB_V3: "S-Miles Cloud Web",
     AUTH_MODE_INSTALLER_V3: "S-Miles Installer",
-    AUTH_MODE_HOME_V3: "S-Miles Home",
+    AUTH_MODE_HOME_V3: "S-Miles Home (not yet supported)",
     AUTH_MODE_LEGACY_V0: "Legacy v0",
 }
 

--- a/custom_components/hoymiles_cloud/data.py
+++ b/custom_components/hoymiles_cloud/data.py
@@ -8,9 +8,12 @@ from typing import Any
 
 from .const import (
     BATTERY_MODE_ECONOMY,
+    BATTERY_MODE_BACKUP_MAX_POWER,
     BATTERY_MODE_IDS,
+    BATTERY_MODE_SELF_CONSUMPTION_MAX_POWER,
     BATTERY_MODE_TIME_OF_USE,
     BATTERY_SCHEDULE_MODE_IDS,
+    METER_LOCATION_NAMES,
 )
 
 
@@ -19,6 +22,8 @@ MODE_KEY_MAPPING = {
     2: "k_2",
     3: "k_3",
     4: "k_4",
+    5: "k_5",
+    6: "k_6",
     7: "k_7",
     8: "k_8",
 }
@@ -500,6 +505,23 @@ def build_empty_battery_settings(
     }
 
 
+def build_empty_relay_settings(
+    *,
+    readable: bool = False,
+    writable: bool = False,
+    status: str | None = None,
+    message: str | None = None,
+) -> dict[str, Any]:
+    """Build a consistent relay-settings payload."""
+    return {
+        "readable": readable,
+        "writable": writable,
+        "data": {},
+        "error_status": status,
+        "error_message": message,
+    }
+
+
 def battery_settings_readable(battery_settings: dict[str, Any] | None) -> bool:
     """Return whether the battery settings endpoint is readable."""
     return bool(battery_settings and battery_settings.get("readable"))
@@ -508,6 +530,40 @@ def battery_settings_readable(battery_settings: dict[str, Any] | None) -> bool:
 def battery_settings_writable(battery_settings: dict[str, Any] | None) -> bool:
     """Return whether battery settings can be written."""
     return bool(battery_settings and battery_settings.get("writable"))
+
+
+def relay_settings_readable(relay_settings: dict[str, Any] | None) -> bool:
+    """Return whether the relay settings endpoint is readable."""
+    return bool(relay_settings and relay_settings.get("readable"))
+
+
+def relay_settings_writable(relay_settings: dict[str, Any] | None) -> bool:
+    """Return whether relay settings can be written."""
+    return bool(relay_settings and relay_settings.get("writable"))
+
+
+def relay_settings_enabled(relay_settings: dict[str, Any] | None) -> bool:
+    """Return whether relay automation appears enabled."""
+    if not relay_settings_readable(relay_settings):
+        return False
+
+    payload = (relay_settings or {}).get("data", {})
+    if not isinstance(payload, dict):
+        return False
+
+    if isinstance(payload.get("mode"), int) and payload.get("mode") != 0:
+        return True
+
+    nested = payload.get("data", {})
+    if not isinstance(nested, dict):
+        return False
+
+    for key in ("k_2", "k_3"):
+        mode = nested.get(key, {}).get("mode")
+        if isinstance(mode, int) and mode != 0:
+            return True
+
+    return False
 
 
 def get_backend_modes(battery_settings: dict[str, Any] | None) -> list[int]:
@@ -536,6 +592,25 @@ def get_supported_modes(battery_settings: dict[str, Any] | None) -> list[int]:
         return [mode for mode in available_modes if isinstance(mode, int) and mode in BATTERY_MODE_IDS]
 
     return [mode for mode in get_backend_modes(battery_settings) if mode in BATTERY_MODE_IDS]
+
+
+def get_allowed_battery_modes(
+    battery_settings: dict[str, Any] | None,
+    setting_rules: dict[str, Any] | None = None,
+) -> list[int]:
+    """Return supported modes after applying station-level restrictions."""
+    supported_modes = get_supported_modes(battery_settings)
+    ctl_mode_set = (setting_rules or {}).get("ctl_mode_set")
+    if not isinstance(ctl_mode_set, list) or not ctl_mode_set:
+        return supported_modes
+
+    restricted_modes = {
+        int(mode)
+        for mode in ctl_mode_set
+        if isinstance(mode, (int, float, str)) and str(mode).strip().isdigit()
+    }
+    allowed = [mode for mode in supported_modes if mode in restricted_modes]
+    return allowed or supported_modes
 
 
 def get_mode_settings(
@@ -574,16 +649,30 @@ def mode_fields(battery_settings: dict[str, Any] | None, mode: int) -> list[str]
     return sorted(get_mode_settings(battery_settings, mode).keys())
 
 
+def get_indicator_value(
+    indicators: dict[str, Any] | None,
+    key: str,
+) -> Any:
+    """Return an indicator value by key."""
+    items = indicators.get("list", []) if indicators else []
+    for item in items:
+        if item.get("key") == key:
+            return item.get("val")
+    return None
+
+
+def get_indicator_map(indicators: dict[str, Any] | None) -> dict[str, Any]:
+    """Return all indicators as a key/value mapping."""
+    items = indicators.get("list", []) if indicators else []
+    return {item.get("key"): item.get("val") for item in items if isinstance(item, dict)}
+
+
 def get_pv_indicator_value(
     pv_indicators: dict[str, Any] | None,
     key: str,
 ) -> Any:
     """Return a PV indicator value by key."""
-    items = pv_indicators.get("list", []) if pv_indicators else []
-    for item in items:
-        if item.get("key") == key:
-            return item.get("val")
-    return None
+    return get_indicator_value(pv_indicators, key)
 
 
 def discover_pv_channels(pv_indicators: dict[str, Any] | None) -> list[int]:
@@ -596,6 +685,13 @@ def discover_pv_channels(pv_indicators: dict[str, Any] | None) -> list[int]:
         if suffix in {"v", "i", "p"} and prefix.isdigit():
             channels.add(int(prefix))
     return sorted(channels)
+
+
+def get_energy_flow_value(energy_flow: dict[str, Any] | None, key: str) -> float | int | None:
+    """Return one energy-flow metric if it exists."""
+    if not energy_flow:
+        return None
+    return energy_flow.get(key)
 
 
 def has_battery_telemetry(real_time_data: dict[str, Any] | None) -> bool:
@@ -613,20 +709,61 @@ def build_station_capabilities(
     pv_indicators: dict[str, Any] | None,
     battery_settings: dict[str, Any] | None,
     microinverters_data: dict[str, Any] | None,
+    grid_indicators: dict[str, Any] | None = None,
+    load_indicators: dict[str, Any] | None = None,
+    energy_flow: dict[str, Any] | None = None,
+    relay_settings: dict[str, Any] | None = None,
+    setting_rules: dict[str, Any] | None = None,
+    devices: dict[str, Any] | None = None,
+    eps_settings: dict[str, Any] | None = None,
+    eps_profit: dict[str, Any] | None = None,
+    ai_status: dict[str, Any] | None = None,
+    firmware: dict[str, Any] | None = None,
+    station_info: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Summarize station capabilities from the current API payloads."""
     pv_channels = discover_pv_channels(pv_indicators)
     battery_settings = battery_settings or {}
+    setting_rules = setting_rules or {}
+    devices = devices or {}
+    allowed_modes = get_allowed_battery_modes(battery_settings, setting_rules)
+    restricted_mode_set = setting_rules.get("ctl_mode_set")
+    meter_locations = [
+        METER_LOCATION_NAMES.get(device.get("location"), str(device.get("location")))
+        for device in devices.get("meters", [])
+        if isinstance(device, dict)
+    ]
 
     return {
         "battery_telemetry": has_battery_telemetry(real_time_data),
         "battery_settings_readable": battery_settings_readable(battery_settings),
         "battery_settings_writable": battery_settings_writable(battery_settings),
+        "relay_settings_readable": relay_settings_readable(relay_settings),
+        "relay_settings_writable": relay_settings_writable(relay_settings),
+        "relay_enabled": relay_settings_enabled(relay_settings),
         "pv_indicators_available": bool((pv_indicators or {}).get("list")),
+        "grid_indicators_available": bool((grid_indicators or {}).get("list")),
+        "load_indicators_available": bool((load_indicators or {}).get("list")),
+        "energy_flow_available": bool(energy_flow),
+        "eps_available": bool(eps_settings),
+        "eps_profit_available": bool(eps_profit),
+        "ai_available": bool(ai_status),
+        "firmware_available": bool(firmware),
         "pv_channels": pv_channels,
         "microinverter_details_available": bool(microinverters_data),
         "microinverter_detail_count": len(microinverters_data or {}),
+        "has_dtu": bool(devices.get("dtus")),
+        "has_inverter": bool(devices.get("inverters")),
+        "has_battery": bool(devices.get("batteries")),
+        "has_meter": bool(devices.get("meters")),
+        "meter_locations": meter_locations,
+        "setting_rules_available": bool(setting_rules),
+        "station_classify": (station_info or {}).get("classify"),
         "supported_battery_modes": get_supported_modes(battery_settings),
+        "allowed_battery_modes": allowed_modes,
         "backend_battery_modes": get_backend_modes(battery_settings),
-        "battery_schedule_modes": get_schedule_modes(battery_settings),
+        "battery_schedule_modes": [mode for mode in allowed_modes if mode_supports_schedule(mode)],
+        "restricted_mode_set": restricted_mode_set if isinstance(restricted_mode_set, list) else [],
+        "supports_mode_5": BATTERY_MODE_SELF_CONSUMPTION_MAX_POWER in get_backend_modes(battery_settings),
+        "supports_mode_6": BATTERY_MODE_BACKUP_MAX_POWER in get_backend_modes(battery_settings),
     }

--- a/custom_components/hoymiles_cloud/device.py
+++ b/custom_components/hoymiles_cloud/device.py
@@ -1,0 +1,236 @@
+"""Device helpers for Hoymiles station and child devices."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .const import DOMAIN, METER_LOCATION_NAMES
+
+
+def _text(value: Any, default: str | None = None) -> str | None:
+    """Return a clean display string or the supplied default."""
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _via_station(station_id: str) -> tuple[str, str]:
+    """Return the device identifier tuple for the parent station."""
+    return (DOMAIN, station_id)
+
+
+def _build_device_info(
+    identifier: tuple[str, str],
+    *,
+    name: str,
+    manufacturer: str = "Hoymiles",
+    model: str | None = None,
+    sw_version: str | None = None,
+    hw_version: str | None = None,
+    via_device: tuple[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build a Home Assistant compatible device-info dictionary."""
+    info: dict[str, Any] = {
+        "identifiers": {identifier},
+        "name": name,
+        "manufacturer": manufacturer,
+    }
+    if model:
+        info["model"] = model
+    if sw_version:
+        info["sw_version"] = sw_version
+    if hw_version:
+        info["hw_version"] = hw_version
+    if via_device:
+        info["via_device"] = via_device
+    return info
+
+
+def build_station_device_info(
+    station_id: str,
+    station_name: str,
+    station_info: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the top-level station device info."""
+    station_info = station_info or {}
+    classify = station_info.get("classify")
+    if classify == 4:
+        model = "Energy Storage Plant"
+    else:
+        model = "Solar Plant"
+    return _build_device_info(
+        (DOMAIN, station_id),
+        name=_text(station_info.get("name"), station_name) or station_name,
+        model=model,
+    )
+
+
+def build_dtu_device_info(
+    station_id: str,
+    station_name: str,
+    dtu: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the DTU device info."""
+    serial = _text(dtu.get("sn") or dtu.get("dtu_sn") or dtu.get("id"), "unknown")
+    return _build_device_info(
+        (DOMAIN, f"dtu_{serial}"),
+        name=f"{station_name} DTU {serial}",
+        model=_text(dtu.get("model_no"), "DTU"),
+        sw_version=_text(dtu.get("soft_ver")),
+        hw_version=_text(dtu.get("hard_ver")),
+        via_device=_via_station(station_id),
+    )
+
+
+def build_inverter_device_info(
+    station_id: str,
+    station_name: str,
+    inverter: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the inverter device info."""
+    serial = _text(inverter.get("sn") or inverter.get("id"), "unknown")
+    model = _text(inverter.get("model_no"), "Inverter")
+    return _build_device_info(
+        (DOMAIN, f"inverter_{serial}"),
+        name=f"{station_name} Inverter {serial}",
+        model=model,
+        sw_version=_text(inverter.get("soft_ver") or inverter.get("sys_soft_ver")),
+        hw_version=_text(inverter.get("hard_ver")),
+        via_device=_via_station(station_id),
+    )
+
+
+def build_battery_device_info(
+    station_id: str,
+    station_name: str,
+    battery: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the battery device info."""
+    serial = _text(battery.get("sn") or battery.get("id"), "unknown")
+    capacity = _text(battery.get("cap"))
+    model = f"Battery {capacity} kWh" if capacity else f"BMS Type {_text(battery.get('bms_type'), 'Unknown')}"
+    return _build_device_info(
+        (DOMAIN, f"battery_{serial}"),
+        name=f"{station_name} Battery {serial}",
+        model=model,
+        sw_version=_text(battery.get("soft_ver")),
+        hw_version=_text(battery.get("hard_ver")),
+        via_device=_via_station(station_id),
+    )
+
+
+def build_meter_device_info(
+    station_id: str,
+    station_name: str,
+    meter: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the meter device info."""
+    serial = _text(meter.get("sn") or meter.get("id"), "unknown")
+    location = METER_LOCATION_NAMES.get(meter.get("location"), "Meter")
+    model = _text(meter.get("model_no"), location)
+    return _build_device_info(
+        (DOMAIN, f"meter_{serial}"),
+        name=f"{station_name} {location} {serial}",
+        model=model,
+        sw_version=_text(meter.get("soft_ver")),
+        hw_version=_text(meter.get("hard_ver")),
+        via_device=_via_station(station_id),
+    )
+
+
+def get_device_list(station_data: dict[str, Any], kind: str) -> list[dict[str, Any]]:
+    """Return the device list for one device kind."""
+    return list((station_data.get("devices") or {}).get(kind, []))
+
+
+def get_primary_device(
+    station_data: dict[str, Any],
+    kind: str,
+    predicate: Callable[[dict[str, Any]], bool] | None = None,
+) -> dict[str, Any] | None:
+    """Return the first matching device for a device kind."""
+    for device in get_device_list(station_data, kind):
+        if predicate is None or predicate(device):
+            return device
+    return None
+
+
+def get_primary_dtu(station_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the first DTU for a station."""
+    return get_primary_device(station_data, "dtus")
+
+
+def get_primary_inverter(station_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the first inverter for a station."""
+    return get_primary_device(station_data, "inverters")
+
+
+def get_primary_battery(station_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the first battery for a station."""
+    return get_primary_device(station_data, "batteries")
+
+
+def get_primary_meter(
+    station_data: dict[str, Any],
+    *,
+    location: int | None = None,
+) -> dict[str, Any] | None:
+    """Return the first matching meter for a station."""
+    if location is None:
+        return get_primary_device(station_data, "meters")
+    return get_primary_device(
+        station_data,
+        "meters",
+        predicate=lambda meter: meter.get("location") == location,
+    )
+
+
+def build_primary_inverter_device_info(
+    station_id: str,
+    station_name: str,
+    station_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the primary inverter device info or fall back to the station."""
+    inverter = get_primary_inverter(station_data)
+    if inverter:
+        return build_inverter_device_info(station_id, station_name, inverter)
+    return build_station_device_info(station_id, station_name, station_data.get("station_info"))
+
+
+def build_primary_battery_device_info(
+    station_id: str,
+    station_name: str,
+    station_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the primary battery device info or fall back to the station."""
+    battery = get_primary_battery(station_data)
+    if battery:
+        return build_battery_device_info(station_id, station_name, battery)
+    return build_station_device_info(station_id, station_name, station_data.get("station_info"))
+
+
+def build_primary_dtu_device_info(
+    station_id: str,
+    station_name: str,
+    station_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the primary DTU device info or fall back to the station."""
+    dtu = get_primary_dtu(station_data)
+    if dtu:
+        return build_dtu_device_info(station_id, station_name, dtu)
+    return build_station_device_info(station_id, station_name, station_data.get("station_info"))
+
+
+def build_primary_meter_device_info(
+    station_id: str,
+    station_name: str,
+    station_data: dict[str, Any],
+    *,
+    location: int | None = None,
+) -> dict[str, Any]:
+    """Return the primary meter device info or fall back to the station."""
+    meter = get_primary_meter(station_data, location=location)
+    if meter:
+        return build_meter_device_info(station_id, station_name, meter)
+    return build_station_device_info(station_id, station_name, station_data.get("station_info"))

--- a/custom_components/hoymiles_cloud/diagnostics.py
+++ b/custom_components/hoymiles_cloud/diagnostics.py
@@ -1,0 +1,126 @@
+"""Diagnostics support for Hoymiles Cloud."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+try:
+    from homeassistant.components.diagnostics import async_redact_data
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+except ImportError:  # pragma: no cover - enables pure unit tests without Home Assistant
+    ConfigEntry = Any  # type: ignore[misc,assignment]
+    HomeAssistant = Any  # type: ignore[misc,assignment]
+
+    def async_redact_data(data: dict[str, Any], redact_keys: set[str]) -> dict[str, Any]:
+        """Minimal fallback redactor for unit-test environments."""
+        def _redact(value: Any) -> Any:
+            if isinstance(value, dict):
+                return {
+                    key: ("**REDACTED**" if key in redact_keys else _redact(item))
+                    for key, item in value.items()
+                }
+            if isinstance(value, list):
+                return [_redact(item) for item in value]
+            return value
+
+        return _redact(data)
+
+from .const import CONF_APP_VERSION, CONF_AUTH_MODE, DOMAIN
+
+REDACT_KEYS = {
+    "address",
+    "addr",
+    "authorization",
+    "ch",
+    "email",
+    "lat",
+    "latitude",
+    "lng",
+    "longitude",
+    "password",
+    "sn",
+    "token",
+    "u",
+    "user_name",
+    "username",
+}
+
+
+def _redact_schedule_shapes(value: Any) -> Any:
+    """Redact bulky schedule arrays while leaving the shape understandable."""
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            if key in {"date", "time", "date_windows", "periods", "draft_payload", "live_payload"}:
+                redacted[key] = "<redacted>"
+            else:
+                redacted[key] = _redact_schedule_shapes(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_schedule_shapes(item) for item in value]
+    return value
+
+
+def _station_summary(station_data: dict[str, Any]) -> dict[str, Any]:
+    """Return a concise station diagnostics summary."""
+    devices = station_data.get("devices", {})
+    return {
+        "station_info": station_data.get("station_info", {}),
+        "device_inventory": {
+            "dtus": devices.get("dtus", []),
+            "inverters": devices.get("inverters", []),
+            "batteries": devices.get("batteries", []),
+            "meters": devices.get("meters", []),
+        },
+        "setting_rules": station_data.get("setting_rules", {}),
+        "capabilities": station_data.get("capabilities", {}),
+        "battery_settings": _redact_schedule_shapes(station_data.get("battery_settings", {})),
+        "relay_settings": _redact_schedule_shapes(station_data.get("relay_settings", {})),
+        "eps_settings": station_data.get("eps_settings", {}),
+        "eps_profit": station_data.get("eps_profit", {}),
+        "ai_status": station_data.get("ai_status", {}),
+        "firmware": station_data.get("firmware", {}),
+        "schedule_editor": _redact_schedule_shapes(station_data.get("schedule_editor", {})),
+        "data_shape": sorted(station_data.keys()),
+    }
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for one Hoymiles config entry."""
+    runtime = hass.data[DOMAIN][entry.entry_id]
+    coordinator = runtime["coordinator"]
+    api = runtime["api"]
+    coordinator_data = coordinator.data or {}
+
+    payload = {
+        "config_entry": {
+            "entry_id": entry.entry_id,
+            "title": entry.title,
+            "auth_mode": entry.data.get(CONF_AUTH_MODE),
+            "app_version": entry.data.get(CONF_APP_VERSION),
+            "options": dict(entry.options),
+        },
+        "auth": {
+            "selected_mode": entry.data.get(CONF_AUTH_MODE),
+            "auth_method": api.auth_method,
+            "last_auth_attempt": api.last_auth_attempt,
+            "last_auth_status": api.last_auth_status,
+            "last_auth_message": api.last_auth_message,
+            "last_auth_attempt_summary": api.last_auth_attempt_summary,
+        },
+        "coordinator": {
+            "last_update_success": coordinator.last_update_success,
+            "station_count": len(coordinator_data),
+            "stations": {
+                station_id: _station_summary(deepcopy(station_data))
+                for station_id, station_data in coordinator_data.items()
+            },
+        },
+    }
+
+    return async_redact_data(payload, REDACT_KEYS)

--- a/custom_components/hoymiles_cloud/hoymiles_api.py
+++ b/custom_components/hoymiles_cloud/hoymiles_api.py
@@ -3,6 +3,7 @@ import asyncio
 import base64
 import binascii
 from copy import deepcopy
+from datetime import datetime
 import hashlib
 import json
 import logging
@@ -18,18 +19,32 @@ from .const import (
     API_AUTH_V3_URL,
     API_USER_ME_URL,
     API_STATIONS_URL,
+    API_STATION_BATTERY_CONFIG_URL,
+    API_STATION_DETAILS_URL,
+    API_STATION_SETTING_RULE_URL,
     API_REAL_TIME_DATA_URL,
+    API_ENERGY_FLOW_STATS_URL,
     API_MICROINVERTERS_URL,
     API_MICRO_DETAIL_URL,
-    API_PV_INDICATORS_URL,
+    API_DTUS_URL,
+    API_INVERTERS_URL,
+    API_BATTERIES_URL,
+    API_METERS_URL,
+    API_INDICATORS_URL,
     API_BATTERY_SETTINGS_READ_URL,
     API_BATTERY_SETTINGS_WRITE_URL,
     API_BATTERY_SETTINGS_STATUS_URL,
+    API_EPS_SETTINGS_URL,
+    API_EPS_PROFIT_URL,
+    API_AI_STATUS_URL,
+    API_FIRMWARE_STATUS_URL,
     BATTERY_MODE_ECONOMY,
     BATTERY_MODE_IDS,
     BATTERY_MODE_SELF_CONSUMPTION,
+    BATTERY_MODE_SELF_CONSUMPTION_MAX_POWER,
     BATTERY_MODE_TIME_OF_USE,
     BATTERY_MODE_BACKUP,
+    BATTERY_MODE_BACKUP_MAX_POWER,
     BATTERY_MODES,
     AUTH_MODE_AUTO,
     AUTH_MODE_HOME_V3,
@@ -41,12 +56,22 @@ from .const import (
     CLIENT_PROFILE_HOME,
     CLIENT_PROFILE_INSTALLER,
     CLIENT_PROFILE_WEB,
+    INDICATOR_TYPE_GRID,
+    INDICATOR_TYPE_LOAD,
+    INDICATOR_TYPE_PV,
+    ENERGY_FLOW_STAT_TYPE_FULL,
+    BATTERY_SETTINGS_ACTION_ID,
+    RELAY_SETTINGS_ACTION_ID,
+    BATTERY_SETTINGS_STATUS_RUNNING,
+    BATTERY_SETTINGS_STATUS_SUCCESS,
 )
 from .data import (
     MODE_KEY_MAPPING,
     battery_settings_readable,
     build_empty_battery_settings,
+    build_empty_relay_settings,
     get_mode_settings,
+    relay_settings_readable,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,13 +82,11 @@ DEFAULT_MODE_SETTINGS: dict[int, dict[str, Any]] = {
     BATTERY_MODE_ECONOMY: {"reserve_soc": 10, "money_code": "$", "date": []},
     BATTERY_MODE_BACKUP: {"reserve_soc": 100},
     4: {},
+    BATTERY_MODE_SELF_CONSUMPTION_MAX_POWER: {"reserve_soc": 70, "max_power": 50.0},
+    BATTERY_MODE_BACKUP_MAX_POWER: {"reserve_soc": 30, "max_power": 50.0},
     7: {"reserve_soc": 30, "max_soc": 70, "meter_power": 3000},
     BATTERY_MODE_TIME_OF_USE: {"reserve_soc": 10},
 }
-
-BATTERY_SETTINGS_ACTION_ID = 1013
-BATTERY_SETTINGS_STATUS_RUNNING = 2
-BATTERY_SETTINGS_STATUS_SUCCESS = 0
 BATTERY_SETTINGS_MAX_POLLS = 10
 BATTERY_SETTINGS_POLL_INTERVAL = 1.0
 
@@ -210,6 +233,81 @@ class HoymilesAPI:
             # The API expects the raw token, not a Bearer prefix.
             headers["Authorization"] = self._token
         return headers
+
+    async def _ensure_authenticated(self) -> None:
+        """Authenticate if needed before an API request."""
+        if not self._token or self.is_token_expired():
+            await self.authenticate()
+
+    async def _post_json(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        *,
+        authenticated: bool = True,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Send a POST request and decode the JSON body."""
+        if authenticated:
+            await self._ensure_authenticated()
+        request_headers = headers or (self._auth_headers() if authenticated else self._json_headers())
+        async with self._session.post(url, headers=request_headers, json=payload) as response:
+            resp_text = await response.text()
+        return json.loads(resp_text)
+
+    async def _fetch_paged_station_list(
+        self,
+        url: str,
+        station_id: str,
+        *,
+        page_size: int = 100,
+        extra_payload: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return a full paginated list for one station-scoped endpoint."""
+        items: list[dict[str, Any]] = []
+        page_num = 1
+        total: int | None = None
+        extra_payload = extra_payload or {}
+
+        while True:
+            payload = {
+                "sid": int(station_id),
+                "page_size": page_size,
+                "page_num": page_num,
+                **extra_payload,
+            }
+            response = await self._post_json(url, payload)
+            if response.get("status") != "0" or response.get("message") != "success":
+                _LOGGER.debug(
+                    "Paged station request to %s failed for %s: %s - %s",
+                    url,
+                    station_id,
+                    response.get("status"),
+                    response.get("message"),
+                )
+                return []
+
+            data = response.get("data", {})
+            page_items = data.get("list", []) if isinstance(data, dict) else []
+            if not isinstance(page_items, list):
+                return []
+            items.extend(item for item in page_items if isinstance(item, dict))
+
+            if total is None and isinstance(data, dict) and data.get("total") is not None:
+                try:
+                    total = int(data["total"])
+                except (TypeError, ValueError):
+                    total = None
+
+            if not page_items:
+                break
+            if total is not None and len(items) >= total:
+                break
+            if len(page_items) < page_size:
+                break
+            page_num += 1
+
+        return items
 
     def _record_auth_failure(self, attempt: AuthAttempt) -> AuthAttempt:
         """Persist a failed auth attempt."""
@@ -719,6 +817,135 @@ class HoymilesAPI:
             _LOGGER.error("Error getting stations: %s", e)
             raise
 
+    async def get_station_details(self, station_id: str) -> dict[str, Any]:
+        """Return the full station details payload."""
+        response = await self._post_json(
+            API_STATION_DETAILS_URL,
+            {"id": int(station_id)},
+        )
+        if response.get("status") == "0" and response.get("message") == "success":
+            return response.get("data", {}) if isinstance(response.get("data"), dict) else {}
+        return {}
+
+    async def get_setting_rules(self, station_id: str) -> dict[str, Any]:
+        """Return station capability flags."""
+        response = await self._post_json(
+            API_STATION_SETTING_RULE_URL,
+            {"sid": int(station_id)},
+        )
+        if response.get("status") == "0" and response.get("message") == "success":
+            return response.get("data", {}) if isinstance(response.get("data"), dict) else {}
+        return {}
+
+    async def get_dtus(self, station_id: str) -> list[dict[str, Any]]:
+        """Return all DTUs for a station."""
+        return await self._fetch_paged_station_list(API_DTUS_URL, station_id)
+
+    async def get_inverters(self, station_id: str) -> list[dict[str, Any]]:
+        """Return all string inverters for a station."""
+        return await self._fetch_paged_station_list(API_INVERTERS_URL, station_id)
+
+    async def get_batteries(self, station_id: str) -> list[dict[str, Any]]:
+        """Return all batteries for a station."""
+        return await self._fetch_paged_station_list(API_BATTERIES_URL, station_id)
+
+    async def get_meters(self, station_id: str) -> list[dict[str, Any]]:
+        """Return all meters for a station."""
+        return await self._fetch_paged_station_list(API_METERS_URL, station_id)
+
+    async def get_indicator_data(
+        self,
+        station_id: str,
+        indicator_type: int,
+    ) -> dict[str, Any]:
+        """Return one indicator payload by type."""
+        response = await self._post_json(
+            API_INDICATORS_URL,
+            {"sid": int(station_id), "type": indicator_type},
+        )
+        if response.get("status") == "0" and response.get("message") == "success":
+            return response.get("data", {}) if isinstance(response.get("data"), dict) else {}
+        return {}
+
+    async def get_load_indicators(self, station_id: str) -> dict[str, Any]:
+        """Return load indicators."""
+        return await self.get_indicator_data(station_id, INDICATOR_TYPE_LOAD)
+
+    async def get_grid_indicators(self, station_id: str) -> dict[str, Any]:
+        """Return grid indicators."""
+        return await self.get_indicator_data(station_id, INDICATOR_TYPE_GRID)
+
+    async def get_energy_flow(
+        self,
+        station_id: str,
+        *,
+        mode: int = 1,
+        date: str | None = None,
+        flow_type: int = ENERGY_FLOW_STAT_TYPE_FULL,
+    ) -> dict[str, Any]:
+        """Return station energy-flow stats."""
+        if date is None:
+            if mode == 1:
+                date = datetime.now().strftime("%Y-%m-%d")
+            elif mode == 2:
+                date = datetime.now().strftime("%Y-%m")
+            elif mode == 3:
+                date = datetime.now().strftime("%Y")
+            else:
+                date = ""
+        response = await self._post_json(
+            API_ENERGY_FLOW_STATS_URL,
+            {
+                "sid": int(station_id),
+                "mode": mode,
+                "date": date,
+                "type": flow_type,
+            },
+        )
+        if response.get("status") == "0" and response.get("message") == "success":
+            return response.get("data", {}) if isinstance(response.get("data"), dict) else {}
+        return {}
+
+    async def get_eps_settings(self, station_id: str) -> dict[str, Any]:
+        """Return current EPS price settings."""
+        response = await self._post_json(
+            API_EPS_SETTINGS_URL,
+            {"sid": int(station_id)},
+        )
+        if response.get("status") == "0" and response.get("message") == "success":
+            return response.get("data", {}) if isinstance(response.get("data"), dict) else {}
+        return {}
+
+    async def get_eps_profit(self, station_id: str) -> dict[str, Any]:
+        """Return EPS profit and spend counters."""
+        response = await self._post_json(
+            API_EPS_PROFIT_URL,
+            {"sid": int(station_id)},
+        )
+        if response.get("status") == "0" and response.get("message") == "success":
+            return response.get("data", {}) if isinstance(response.get("data"), dict) else {}
+        return {}
+
+    async def get_ai_status(self, station_id: str) -> dict[str, Any]:
+        """Return AI mode metadata for a station."""
+        response = await self._post_json(
+            API_AI_STATUS_URL,
+            {"sid": int(station_id)},
+        )
+        if response.get("status") == "0" and response.get("message") == "success":
+            return response.get("data", {}) if isinstance(response.get("data"), dict) else {}
+        return {}
+
+    async def get_firmware_status(self, station_id: str) -> dict[str, Any]:
+        """Return firmware update availability for a station."""
+        response = await self._post_json(
+            API_FIRMWARE_STATUS_URL,
+            {"sid": int(station_id)},
+        )
+        if response.get("status") == "0" and response.get("message") == "success":
+            return response.get("data", {}) if isinstance(response.get("data"), dict) else {}
+        return {}
+
     async def get_microinverters_by_stations(self, station_id: str) -> Dict[str, str]:
         """Get all microinverters with detail for a station."""
         if not self._token or self.is_token_expired():
@@ -841,32 +1068,7 @@ class HoymilesAPI:
 
     async def get_pv_indicators(self, station_id: str) -> Dict[str, Any]:
         """Get PV indicators data for a station."""
-        if not self._token or self.is_token_expired():
-            await self.authenticate()
-
-        data = {
-            "sid": int(station_id),
-            "type": 4  # PV indicators type
-        }
-        
-        try:
-            async with self._session.post(
-                API_PV_INDICATORS_URL, headers=self._auth_headers(), json=data
-            ) as response:
-                resp = await response.json()
-                
-                if resp.get("status") == "0" and resp.get("message") == "success":
-                    return resp.get("data", {})
-                else:
-                    _LOGGER.error(
-                        "Failed to get PV indicators data: %s - %s", 
-                        resp.get("status"), 
-                        resp.get("message")
-                    )
-                    return {}
-        except Exception as e:
-            _LOGGER.error("Error getting PV indicators data: %s", e)
-            raise
+        return await self.get_indicator_data(station_id, INDICATOR_TYPE_PV)
 
     async def get_battery_settings(self, station_id: str) -> Dict[str, Any]:
         """Get battery settings for a station."""
@@ -895,9 +1097,65 @@ class HoymilesAPI:
 
         return self._parse_battery_settings_response(final_response)
 
+    async def get_relay_settings(self, station_id: str) -> dict[str, Any]:
+        """Get relay / dry-contact settings for a station."""
+        await self._ensure_authenticated()
+        try:
+            response = await self._submit_battery_settings_command(
+                API_BATTERY_SETTINGS_READ_URL,
+                {
+                    "action": RELAY_SETTINGS_ACTION_ID,
+                    "data": {"sid": int(station_id)},
+                },
+                log_label=f"relay settings read for station {station_id}",
+            )
+            final_response = await self._resolve_battery_settings_command(
+                response,
+                expect_result=True,
+                command_label=f"relay settings read for station {station_id}",
+            )
+        except json.JSONDecodeError as err:
+            _LOGGER.warning("Error decoding relay settings JSON: %s", err)
+            return build_empty_relay_settings(message="Invalid relay settings response")
+        except Exception as err:
+            _LOGGER.warning("Error checking relay settings status: %s", err)
+            return build_empty_relay_settings(message="Unable to read relay settings")
+
+        return self._parse_relay_settings_response(final_response)
+
     def _default_mode_settings(self, mode: int) -> dict[str, Any]:
         """Return default settings for a battery mode."""
         return deepcopy(DEFAULT_MODE_SETTINGS.get(mode, {}))
+
+    def _parse_relay_settings_response(self, response: dict[str, Any]) -> dict[str, Any]:
+        """Normalize a completed relay settings response."""
+        if response.get("status") != "0" or response.get("message") != "success":
+            return build_empty_relay_settings(
+                status=str(response.get("status")),
+                message=str(response.get("message")),
+            )
+
+        response_data = response.get("data", {})
+        if not isinstance(response_data, dict):
+            return build_empty_relay_settings(message="Missing relay settings data")
+
+        status_code = response_data.get("code")
+        if status_code not in (None, BATTERY_SETTINGS_STATUS_SUCCESS):
+            return build_empty_relay_settings(
+                message=response_data.get("message") or "Relay settings are still pending",
+            )
+
+        settings_payload = response_data.get("data")
+        if not isinstance(settings_payload, dict):
+            return build_empty_relay_settings(message="Missing relay settings payload")
+
+        return {
+            "readable": True,
+            "writable": True,
+            "data": deepcopy(settings_payload),
+            "error_status": None,
+            "error_message": None,
+        }
 
     async def _submit_battery_settings_command(
         self,
@@ -1030,6 +1288,34 @@ class HoymilesAPI:
                 merged[key] = deepcopy(value)
         return merged
 
+    async def set_battery_config_direct(
+        self,
+        station_id: str,
+        mode: int,
+        mode_settings: dict[str, Any],
+    ) -> bool:
+        """Write a full battery-mode payload through the direct PVM endpoint."""
+        await self._ensure_authenticated()
+        response = await self._post_json(
+            API_STATION_BATTERY_CONFIG_URL,
+            {
+                "sid": int(station_id),
+                "mode": mode,
+                "data": deepcopy(mode_settings),
+            },
+        )
+        if response.get("status") == "0" and response.get("message") == "success":
+            return bool(response.get("data", True))
+
+        _LOGGER.error(
+            "Failed direct battery write for station %s mode %s: %s - %s",
+            station_id,
+            mode,
+            response.get("status"),
+            response.get("message"),
+        )
+        return False
+
     async def _write_battery_mode_payload(
         self, station_id: str, mode: int, mode_settings: dict[str, Any]
     ) -> bool:
@@ -1098,6 +1384,44 @@ class HoymilesAPI:
         )
         return False
 
+    async def _write_relay_payload(self, station_id: str, relay_payload: dict[str, Any]) -> bool:
+        """Write a relay payload through the async control endpoint."""
+        await self._ensure_authenticated()
+        try:
+            response = await self._submit_battery_settings_command(
+                API_BATTERY_SETTINGS_WRITE_URL,
+                {
+                    "action": RELAY_SETTINGS_ACTION_ID,
+                    "data": {
+                        "sid": int(station_id),
+                        "data": deepcopy(relay_payload),
+                    },
+                },
+                log_label=f"relay settings write for station {station_id}",
+            )
+            resolved = await self._resolve_battery_settings_command(
+                response,
+                expect_result=False,
+                command_label=f"relay settings write for station {station_id}",
+            )
+        except json.JSONDecodeError as err:
+            _LOGGER.error("Error decoding relay settings write response: %s", err)
+            return False
+        except Exception as err:
+            _LOGGER.error("Error writing relay settings: %s", err)
+            raise
+
+        if resolved.get("status") == "0" and resolved.get("message") == "success":
+            status_data = resolved.get("data", {})
+            if isinstance(status_data, dict) and status_data.get("code") not in (
+                None,
+                BATTERY_SETTINGS_STATUS_SUCCESS,
+            ):
+                return False
+            return True
+
+        return False
+
     async def _get_writable_mode_settings(
         self, station_id: str, mode: int
     ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
@@ -1148,7 +1472,7 @@ class HoymilesAPI:
             mode_settings.setdefault("money_code", "$")
             mode_settings.setdefault("date", [])
 
-        return await self._write_battery_mode_payload(station_id, mode, mode_settings)
+        return await self.set_battery_config_direct(station_id, mode, mode_settings)
 
     async def set_battery_mode(self, station_id: str, mode: int) -> bool:
         """Set battery mode for a station."""
@@ -1165,7 +1489,7 @@ class HoymilesAPI:
             BATTERY_MODES.get(mode),
             station_id,
         )
-        return await self._write_battery_mode_payload(station_id, mode, mode_settings)
+        return await self.set_battery_config_direct(station_id, mode, mode_settings)
 
     async def set_reserve_soc(self, station_id: str, reserve_soc: int) -> bool:
         """Set battery reserve SOC for a station."""
@@ -1212,3 +1536,34 @@ class HoymilesAPI:
             7,
             updates,
         )
+
+    async def set_relay_enabled(self, station_id: str, enabled: bool) -> bool:
+        """Enable or disable dry-contact control using the current relay payload."""
+        relay_settings = await self.get_relay_settings(station_id)
+        if not relay_settings_readable(relay_settings):
+            _LOGGER.warning("Relay settings are unavailable for station %s", station_id)
+            return False
+
+        relay_payload = deepcopy(relay_settings.get("data", {}))
+        if not isinstance(relay_payload, dict):
+            return False
+
+        nested = relay_payload.setdefault("data", {})
+        if not isinstance(nested, dict):
+            nested = {}
+            relay_payload["data"] = nested
+
+        if enabled:
+            if relay_payload.get("mode") in (None, 0):
+                relay_payload["mode"] = 1
+            if nested.get("k_2", {}).get("mode", 0) == 0 and nested.get("k_3", {}).get("mode", 0) == 0:
+                nested.setdefault("k_2", {})
+                nested["k_2"]["mode"] = 2
+        else:
+            relay_payload["mode"] = 0
+            if isinstance(nested.get("k_2"), dict):
+                nested["k_2"]["mode"] = 0
+            if isinstance(nested.get("k_3"), dict):
+                nested["k_3"]["mode"] = 0
+
+        return await self._write_relay_payload(station_id, relay_payload)

--- a/custom_components/hoymiles_cloud/hoymiles_api.py
+++ b/custom_components/hoymiles_cloud/hoymiles_api.py
@@ -12,11 +12,16 @@ from typing import Any, Dict, Optional
 
 import aiohttp
 
-from .auth import AuthAttempt, choose_preferred_failure, summarize_auth_attempts
+from .auth import (
+    AUTH_ERROR_S_MILES_HOME_REQUIRED,
+    AuthAttempt,
+    choose_preferred_failure,
+    summarize_auth_attempts,
+)
 from .const import (
-    API_AUTH_URL,
-    API_AUTH_PRE_INSP_URL,
-    API_AUTH_V3_URL,
+    AUTH_PATH_LOGIN_V0,
+    AUTH_PATH_PRE_INSP_V3,
+    AUTH_PATH_LOGIN_V3,
     API_USER_ME_URL,
     API_STATIONS_URL,
     API_STATION_BATTERY_CONFIG_URL,
@@ -112,6 +117,7 @@ class HoymilesAPI:
         self._last_auth_attempts: list[AuthAttempt] = []
         self._auth_mode_preference = AUTH_MODE_AUTO
         self._app_version_override: str | None = None
+        self._auth_base_url_override: str | None = None
         self._active_client_profile = CLIENT_PROFILE_WEB
         self._active_app_version: str | None = None
 
@@ -159,10 +165,33 @@ class HoymilesAPI:
         *,
         auth_mode: str = AUTH_MODE_AUTO,
         app_version: str | None = None,
+        auth_base_url: str | None = None,
     ) -> None:
-        """Persist auth preferences for future login attempts."""
+        """Persist auth preferences for future login attempts.
+
+        ``auth_base_url`` is an advanced override that points the auth
+        endpoints at a different host (e.g. a candidate S-Miles Home consumer
+        backend discovered via a network trace). It wins over the per-profile
+        default and is intended for investigation via
+        ``scripts/test_login_flow.py`` rather than the end-user config flow.
+        """
         self._auth_mode_preference = auth_mode
         self._app_version_override = app_version.strip() if app_version else None
+        self._auth_base_url_override = auth_base_url.strip() if auth_base_url else None
+
+    def _auth_url(self, client_profile: str, path: str) -> str | None:
+        """Resolve the full auth URL for a profile, honoring any override.
+
+        Returns ``None`` when the profile has no configured backend host
+        (e.g. the S-Miles Home consumer backend is not yet known), so callers
+        can fail fast instead of silently falling back to the wrong host.
+        """
+        base_url = self._auth_base_url_override or AUTH_PROFILE_DEFAULTS[client_profile].get(
+            "base_url"
+        )
+        if not base_url:
+            return None
+        return f"{base_url.rstrip('/')}{path}"
 
     def _set_auth_failure(self, status: Optional[str], message: Optional[str]) -> None:
         """Store the most recent authentication failure."""
@@ -332,12 +361,22 @@ class HoymilesAPI:
             return [(AUTH_MODE_LEGACY_V0, CLIENT_PROFILE_WEB)]
         if auth_mode in AUTH_MODE_TO_PROFILE:
             return [(auth_mode, AUTH_MODE_TO_PROFILE[auth_mode])]
-        return [
+        # Auto-detect: skip profiles whose backend host is unresolved (e.g. the
+        # S-Miles Home consumer backend), so a wrong password is not mislabeled
+        # as an S-Miles Home account. Such profiles are only tried when the user
+        # selects them explicitly.
+        candidates = [
             (AUTH_MODE_WEB_V3, CLIENT_PROFILE_WEB),
             (AUTH_MODE_INSTALLER_V3, CLIENT_PROFILE_INSTALLER),
             (AUTH_MODE_HOME_V3, CLIENT_PROFILE_HOME),
-            (AUTH_MODE_LEGACY_V0, CLIENT_PROFILE_WEB),
         ]
+        attempts = [
+            (mode, profile)
+            for mode, profile in candidates
+            if self._auth_url(profile, AUTH_PATH_LOGIN_V3) is not None
+        ]
+        attempts.append((AUTH_MODE_LEGACY_V0, CLIENT_PROFILE_WEB))
+        return attempts
 
     def _parse_pre_insp_response(
         self,
@@ -403,11 +442,12 @@ class HoymilesAPI:
         method_name: str,
         headers: dict[str, str],
         app_version: str | None,
+        url: str,
     ) -> AuthAttempt | tuple[dict[str, Any], str | None]:
         """Run v3 pre-inspection and return normalized data or a failed attempt."""
         try:
             async with self._session.post(
-                API_AUTH_PRE_INSP_URL,
+                url,
                 headers=headers,
                 json={"u": self._username},
             ) as response:
@@ -469,11 +509,12 @@ class HoymilesAPI:
         credential_hash: str,
         nonce: str,
         variant_name: str,
+        url: str,
     ) -> AuthAttempt:
         """Attempt a single v3 login candidate."""
         try:
             async with self._session.post(
-                API_AUTH_V3_URL,
+                url,
                 headers=headers,
                 json={"u": self._username, "ch": credential_hash, "n": nonce},
             ) as response:
@@ -546,12 +587,32 @@ class HoymilesAPI:
         app_version = self._resolve_app_version(client_profile)
         headers = self._json_headers(client_profile=client_profile, app_version=app_version)
 
+        # Resolve the backend host for this profile. A missing host means the
+        # profile's backend is not yet known (e.g. the S-Miles Home consumer
+        # backend), so fail fast instead of hitting the wrong host.
+        pre_insp_url = self._auth_url(client_profile, AUTH_PATH_PRE_INSP_V3)
+        login_url = self._auth_url(client_profile, AUTH_PATH_LOGIN_V3)
+        if not pre_insp_url or not login_url:
+            return self._record_auth_failure(
+                AuthAttempt(
+                    method=method_name,
+                    client_profile=client_profile,
+                    success=False,
+                    message=(
+                        "S-Miles Home backend not yet configured. This account type "
+                        "is not supported yet (see GitHub issue #30)."
+                    ),
+                    app_version=app_version,
+                )
+            )
+
         # Step 1: Pre-inspection — get server-provided salt and nonce
         pre_insp_result = await self._pre_inspect_v3(
             client_profile=client_profile,
             method_name=method_name,
             headers=headers,
             app_version=app_version,
+            url=pre_insp_url,
         )
         if isinstance(pre_insp_result, AuthAttempt):
             return pre_insp_result
@@ -609,6 +670,7 @@ class HoymilesAPI:
                 credential_hash=ch,
                 nonce=nonce,
                 variant_name=auth_method,
+                url=login_url,
             )
 
         last_failure: AuthAttempt | None = None
@@ -619,6 +681,7 @@ class HoymilesAPI:
                     method_name=method_name,
                     headers=headers,
                     app_version=app_version,
+                    url=pre_insp_url,
                 )
                 if isinstance(retry_pre_insp_result, AuthAttempt):
                     return retry_pre_insp_result
@@ -632,6 +695,7 @@ class HoymilesAPI:
                 credential_hash=candidate_hash,
                 nonce=nonce,
                 variant_name=variant_name,
+                url=login_url,
             )
             if attempt.success:
                 return attempt
@@ -657,9 +721,10 @@ class HoymilesAPI:
             "user_name": self._username,
             "password": md5_password,
         }
+        url = self._auth_url(CLIENT_PROFILE_WEB, AUTH_PATH_LOGIN_V0)
         try:
             async with self._session.post(
-                API_AUTH_URL, headers=headers, json=data
+                url, headers=headers, json=data
             ) as response:
                 resp = await response.json()
         except Exception as e:
@@ -711,9 +776,16 @@ class HoymilesAPI:
             attempts: list[AuthAttempt] = []
             for attempt_mode, client_profile in self._build_auth_attempts(selected_auth_mode):
                 if attempt_mode == AUTH_MODE_LEGACY_V0:
-                    attempts.append(await self._authenticate_legacy())
+                    attempt = await self._authenticate_legacy()
                 else:
-                    attempts.append(await self._authenticate_v3(client_profile=client_profile))
+                    attempt = await self._authenticate_v3(client_profile=client_profile)
+                attempts.append(attempt)
+
+                # Once the server reports the account is restricted to the
+                # S-Miles Home app, the remaining profiles hit the same host
+                # and fail identically. Stop early to avoid pointless retries.
+                if not attempt.success and attempt.error_key == AUTH_ERROR_S_MILES_HOME_REQUIRED:
+                    break
 
             self._last_auth_attempts = attempts
             for attempt in attempts:

--- a/custom_components/hoymiles_cloud/manifest.json
+++ b/custom_components/hoymiles_cloud/manifest.json
@@ -5,8 +5,10 @@
   "config_flow": true,
   "documentation": "https://github.com/Philra94/homeassistant-hoymiles-cloud",
   "issue_tracker": "https://github.com/Philra94/homeassistant-hoymiles-cloud/issues",
+  "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "version": "0.5.0",
+  "single_config_entry": false,
+  "version": "1.0.0",
   "requirements": [
     "aiohttp>=3.8.0",
     "argon2-cffi>=21.3.0"

--- a/custom_components/hoymiles_cloud/models.py
+++ b/custom_components/hoymiles_cloud/models.py
@@ -1,0 +1,102 @@
+"""Typed runtime models for the Hoymiles Cloud integration."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class DeviceInventory:
+    """Known devices attached to one Hoymiles station."""
+
+    dtus: list[dict[str, Any]] = field(default_factory=list)
+    inverters: list[dict[str, Any]] = field(default_factory=list)
+    batteries: list[dict[str, Any]] = field(default_factory=list)
+    meters: list[dict[str, Any]] = field(default_factory=list)
+    microinverters: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class EnergyFlow:
+    """Aggregated station energy-flow stats."""
+
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return dict(self.raw)
+
+
+@dataclass(slots=True)
+class EPSProfit:
+    """Profit and spend metrics from the EPS service."""
+
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return dict(self.raw)
+
+
+@dataclass(slots=True)
+class SettingRules:
+    """Station capability flags from the settings-rule endpoint."""
+
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return dict(self.raw)
+
+
+@dataclass(slots=True)
+class AIStatus:
+    """AI/compound mode metadata for a station."""
+
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return dict(self.raw)
+
+
+@dataclass(slots=True)
+class FirmwareStatus:
+    """Firmware availability metadata for a station."""
+
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return dict(self.raw)
+
+
+@dataclass(slots=True)
+class StationData:
+    """Complete coordinator payload for one station."""
+
+    station_info: dict[str, Any] = field(default_factory=dict)
+    real_time_data: dict[str, Any] = field(default_factory=dict)
+    energy_flow: dict[str, Any] = field(default_factory=dict)
+    pv_indicators: dict[str, Any] = field(default_factory=dict)
+    grid_indicators: dict[str, Any] = field(default_factory=dict)
+    load_indicators: dict[str, Any] = field(default_factory=dict)
+    battery_settings: dict[str, Any] = field(default_factory=dict)
+    relay_settings: dict[str, Any] = field(default_factory=dict)
+    eps_settings: dict[str, Any] = field(default_factory=dict)
+    eps_profit: dict[str, Any] = field(default_factory=dict)
+    ai_status: dict[str, Any] = field(default_factory=dict)
+    setting_rules: dict[str, Any] = field(default_factory=dict)
+    devices: dict[str, Any] = field(default_factory=dict)
+    firmware: dict[str, Any] = field(default_factory=dict)
+    schedule_editor: dict[str, Any] = field(default_factory=dict)
+    capabilities: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the coordinator payload format used by entities."""
+        return asdict(self)

--- a/custom_components/hoymiles_cloud/number.py
+++ b/custom_components/hoymiles_cloud/number.py
@@ -12,13 +12,16 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
 from .const import (
+    BATTERY_MODE_BACKUP_MAX_POWER,
     BATTERY_MODE_ECONOMY,
     BATTERY_MODE_PEAK_SHAVING,
+    BATTERY_MODE_SELF_CONSUMPTION_MAX_POWER,
     BATTERY_MODE_TIME_OF_USE,
     BATTERY_MODES,
     DOMAIN,
 )
-from .data import battery_settings_writable, get_mode_settings, get_supported_modes
+from .data import battery_settings_writable, get_allowed_battery_modes, get_mode_settings
+from .device import build_primary_battery_device_info
 from .hoymiles_api import HoymilesAPI
 from .schedule_editor import (
     build_device_info,
@@ -52,7 +55,10 @@ async def async_setup_entry(
         if not battery_settings_writable(battery_settings):
             continue
 
-        supported_modes = get_supported_modes(battery_settings)
+        supported_modes = get_allowed_battery_modes(
+            battery_settings,
+            station_data.get("setting_rules", {}),
+        )
         for mode in supported_modes:
             mode_settings = get_mode_settings(battery_settings, mode)
             if "reserve_soc" in mode_settings:
@@ -64,6 +70,16 @@ async def async_setup_entry(
                         station_name=station_name,
                         mode=mode,
                         update_soc_callback=update_soc,
+                    )
+                )
+            if mode in (BATTERY_MODE_SELF_CONSUMPTION_MAX_POWER, BATTERY_MODE_BACKUP_MAX_POWER) and "max_power" in mode_settings:
+                entities.append(
+                    HoymilesBatteryMaxPower(
+                        coordinator=coordinator,
+                        api=api,
+                        station_id=station_id,
+                        station_name=station_name,
+                        mode=mode,
                     )
                 )
 
@@ -102,9 +118,9 @@ async def async_setup_entry(
                         _tou_period_path,
                         "c_power",
                         0,
-                        20000,
                         100,
-                        "W",
+                        1,
+                        PERCENTAGE,
                     ),
                     HoymilesScheduleNumberEntity(
                         coordinator,
@@ -117,9 +133,9 @@ async def async_setup_entry(
                         _tou_period_path,
                         "dc_power",
                         0,
-                        20000,
                         100,
-                        "W",
+                        1,
+                        PERCENTAGE,
                     ),
                     HoymilesScheduleNumberEntity(
                         coordinator,
@@ -201,7 +217,11 @@ class HoymilesBatteryNumberEntity(CoordinatorEntity, NumberEntity):
         super().__init__(coordinator)
         self._api = api
         self._station_id = station_id
-        self._attr_device_info = build_device_info(station_id, station_name)
+        self._attr_device_info = build_primary_battery_device_info(
+            station_id,
+            station_name,
+            get_station_data(coordinator, station_id),
+        )
         self._attr_entity_category = EntityCategory.CONFIG
 
     def _get_station_data(self) -> dict:
@@ -274,6 +294,48 @@ class HoymilesBatteryReserveSOC(HoymilesBatteryNumberEntity):
         self.async_write_ha_state()
 
 
+class HoymilesBatteryMaxPower(HoymilesBatteryNumberEntity):
+    """Entity for controlling mode 5/6 max_power."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        api: HoymilesAPI,
+        station_id: str,
+        station_name: str,
+        mode: int,
+    ) -> None:
+        """Initialize the max power control."""
+        super().__init__(coordinator, api, station_id, station_name)
+        self._mode = mode
+        self._mode_name = BATTERY_MODES.get(mode, f"Mode {mode}")
+        self._attr_unique_id = f"{DOMAIN}_{station_id}_battery_max_power_{mode}"
+        self._attr_name = f"{station_name} Battery Max Power ({self._mode_name})"
+        self._attr_native_min_value = 0
+        self._attr_native_max_value = 100
+        self._attr_native_step = 1
+        self._attr_mode = NumberMode.SLIDER
+        self._attr_native_unit_of_measurement = PERCENTAGE
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current value."""
+        value = get_mode_settings(self._get_battery_settings(), self._mode).get("max_power")
+        return float(value) if value is not None else None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the max power percentage."""
+        if not await self._api.set_battery_mode_settings(
+            self._station_id,
+            self._mode,
+            {"max_power": float(value)},
+        ):
+            return
+
+        await self.coordinator.async_request_refresh()
+        self.async_write_ha_state()
+
+
 class HoymilesPeakShavingMaxSOC(HoymilesBatteryNumberEntity):
     """Entity for controlling Peak Shaving Mode's max_soc parameter."""
 
@@ -334,7 +396,7 @@ class HoymilesPeakShavingMeterPower(HoymilesBatteryNumberEntity):
         self._attr_unique_id = f"{DOMAIN}_{station_id}_peak_shaving_meter_power"
         self._attr_name = f"{station_name} Peak Shaving Meter Power"
         self._attr_native_min_value = 0
-        self._attr_native_max_value = 10000
+        self._attr_native_max_value = 60000
         self._attr_native_step = 100
         self._attr_mode = NumberMode.BOX
         self._attr_native_unit_of_measurement = "W"

--- a/custom_components/hoymiles_cloud/schedule_editor.py
+++ b/custom_components/hoymiles_cloud/schedule_editor.py
@@ -7,18 +7,13 @@ from .const import (
     BATTERY_MODE_ECONOMY,
     BATTERY_MODE_TIME_OF_USE,
     BATTERY_MODES,
-    DOMAIN,
 )
+from .device import build_station_device_info
 
 
 def build_device_info(station_id: str, station_name: str) -> dict[str, Any]:
     """Return common device metadata for station-scoped entities."""
-    return {
-        "identifiers": {(DOMAIN, station_id)},
-        "name": station_name,
-        "manufacturer": "Hoymiles",
-        "model": "Solar Inverter System",
-    }
+    return build_station_device_info(station_id, station_name)
 
 
 def get_station_data(coordinator, station_id: str) -> dict[str, Any]:

--- a/custom_components/hoymiles_cloud/select.py
+++ b/custom_components/hoymiles_cloud/select.py
@@ -13,7 +13,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpda
 
 from .const import BATTERY_MODES, DOMAIN
 from .const import BATTERY_MODE_ECONOMY, BATTERY_MODE_TIME_OF_USE
-from .data import battery_settings_writable, get_supported_modes
+from .data import battery_settings_writable, get_allowed_battery_modes
+from .device import build_primary_battery_device_info
 from .hoymiles_api import HoymilesAPI
 from .schedule_editor import (
     build_device_info,
@@ -49,7 +50,10 @@ async def async_setup_entry(
     for station_id, station_name in stations.items():
         station_data = coordinator.data.get(station_id, {}) if coordinator.data else {}
         battery_settings = station_data.get("battery_settings", {})
-        if battery_settings_writable(battery_settings) and get_supported_modes(battery_settings):
+        if battery_settings_writable(battery_settings) and get_allowed_battery_modes(
+            battery_settings,
+            station_data.get("setting_rules", {}),
+        ):
             entities.append(
                 HoymilesBatteryModeSelect(
                     coordinator=coordinator,
@@ -114,7 +118,11 @@ class HoymilesBatteryModeSelect(CoordinatorEntity, SelectEntity):
         self._attr_unique_id = f"{DOMAIN}_{station_id}_battery_mode_select"
         self._attr_name = f"{station_name} Battery Mode"
         self._attr_entity_category = EntityCategory.CONFIG
-        self._attr_device_info = build_device_info(station_id, station_name)
+        self._attr_device_info = build_primary_battery_device_info(
+            station_id,
+            station_name,
+            get_station_data(coordinator, station_id),
+        )
         self._attr_options = self._get_current_options()
 
     def _get_station_data(self) -> dict:
@@ -123,10 +131,11 @@ class HoymilesBatteryModeSelect(CoordinatorEntity, SelectEntity):
 
     def _get_current_options(self) -> list[str]:
         """Return supported mode options for this station."""
+        station_data = self._get_station_data()
         battery_settings = self._get_station_data().get("battery_settings", {})
         return [
             MODE_OPTIONS[mode]
-            for mode in get_supported_modes(battery_settings)
+            for mode in get_allowed_battery_modes(battery_settings, station_data.get("setting_rules", {}))
             if mode in MODE_OPTIONS
         ]
 

--- a/custom_components/hoymiles_cloud/sensor.py
+++ b/custom_components/hoymiles_cloud/sensor.py
@@ -1,4 +1,5 @@
 """Sensor platform for Hoymiles Cloud integration."""
+
 from __future__ import annotations
 
 import logging
@@ -18,6 +19,7 @@ from homeassistant.const import (
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
+    UnitOfFrequency,
     UnitOfMass,
     UnitOfPower,
 )
@@ -28,13 +30,26 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from .const import BATTERY_MODES, DOMAIN
+from .const import BATTERY_MODES, DOMAIN, METER_LOCATION_NAMES
 from .data import (
     battery_settings_readable,
     discover_pv_channels,
+    get_allowed_battery_modes,
+    get_energy_flow_value,
+    get_indicator_value,
+    get_mode_settings,
     get_schedule_modes,
     get_supported_modes,
     get_pv_indicator_value,
+)
+from .device import (
+    build_battery_device_info,
+    build_dtu_device_info,
+    build_inverter_device_info,
+    build_meter_device_info,
+    build_primary_battery_device_info,
+    build_primary_inverter_device_info,
+    build_station_device_info,
 )
 from .schedule_editor import (
     get_editor_state,
@@ -85,21 +100,27 @@ def parse_timestamp(timestamp_str: str | None) -> datetime | None:
         return None
 
 
+def get_station_data(coordinator: DataUpdateCoordinator, station_id: str) -> dict[str, Any]:
+    """Return one station payload from the coordinator."""
+    return coordinator.data.get(station_id, {}) if coordinator.data else {}
+
+
+def get_reflux_data(station_data: dict[str, Any]) -> dict[str, Any]:
+    """Return the live reflux payload."""
+    return station_data.get("real_time_data", {}).get("reflux_station_data", {})
+
+
+def get_nested_energy_total(station_data: dict[str, Any], key: str, period: str) -> int | None:
+    """Return one nested energy total from the reflux data."""
+    return safe_int_convert(get_reflux_data(station_data).get(key, {}).get(period))
+
+
 def is_battery_charging(station_data: dict[str, Any]) -> bool | None:
     """Determine whether the battery is charging based on live flows."""
-    try:
-        reflux_data = station_data.get("real_time_data", {}).get("reflux_station_data", {})
-        bms_power = safe_float_convert(reflux_data.get("bms_power"))
-        if bms_power is not None:
-            return bms_power > 0
-
-        for flow in reflux_data.get("flows", []):
-            if flow.get("in") == 4 and safe_float_convert(flow.get("v")):
-                return True
-            if flow.get("out") == 4 and safe_float_convert(flow.get("v")):
-                return False
-    except Exception as err:  # pragma: no cover - defensive logging
-        _LOGGER.debug("Error determining battery charging status: %s", err)
+    reflux_data = get_reflux_data(station_data)
+    bms_power = safe_float_convert(reflux_data.get("bms_power"))
+    if bms_power is not None:
+        return bms_power > 0
     return None
 
 
@@ -108,26 +129,83 @@ def has_pv_indicator(station_data: dict[str, Any], key: str) -> bool:
     return get_pv_indicator_value(station_data.get("pv_indicators", {}), key) is not None
 
 
+def has_grid_indicator(station_data: dict[str, Any], key: str) -> bool:
+    """Return whether a grid indicator key is present."""
+    return get_indicator_value(station_data.get("grid_indicators", {}), key) is not None
+
+
 def has_battery_telemetry(station_data: dict[str, Any]) -> bool:
     """Return whether battery telemetry is available for the station."""
     return bool(station_data.get("capabilities", {}).get("battery_telemetry"))
 
 
+def has_energy_flow(station_data: dict[str, Any]) -> bool:
+    """Return whether energy-flow stats are available."""
+    return bool(station_data.get("capabilities", {}).get("energy_flow_available"))
+
+
+def has_eps_settings(station_data: dict[str, Any]) -> bool:
+    """Return whether EPS settings are available."""
+    return bool(station_data.get("capabilities", {}).get("eps_available"))
+
+
+def has_eps_profit(station_data: dict[str, Any]) -> bool:
+    """Return whether EPS profit metrics are available."""
+    return bool(station_data.get("capabilities", {}).get("eps_profit_available"))
+
+
+def get_station_device_info(station_id: str, station_name: str, station_data: dict[str, Any]) -> dict[str, Any]:
+    """Return station device info."""
+    return build_station_device_info(station_id, station_name, station_data.get("station_info"))
+
+
+def get_battery_device_info(station_id: str, station_name: str, station_data: dict[str, Any]) -> dict[str, Any]:
+    """Return aggregate battery device info."""
+    return build_primary_battery_device_info(station_id, station_name, station_data)
+
+
+def get_inverter_device_info(station_id: str, station_name: str, station_data: dict[str, Any]) -> dict[str, Any]:
+    """Return aggregate inverter device info."""
+    return build_primary_inverter_device_info(station_id, station_name, station_data)
+
+
+def compute_self_consumption_rate(station_data: dict[str, Any]) -> float | None:
+    """Return the PV self-consumption ratio in percent."""
+    pv_to_load = safe_float_convert(get_energy_flow_value(station_data.get("energy_flow"), "p2l"))
+    total_pv = safe_float_convert(station_data.get("real_time_data", {}).get("today_eq"))
+    if pv_to_load is None or total_pv in (None, 0):
+        return None
+    return round((pv_to_load / total_pv) * 100, 2)
+
+
+def compute_self_sufficiency_rate(station_data: dict[str, Any]) -> float | None:
+    """Return the self-sufficiency ratio in percent."""
+    load_from_pv = safe_float_convert(get_energy_flow_value(station_data.get("energy_flow"), "lfp")) or 0.0
+    load_from_battery = safe_float_convert(get_energy_flow_value(station_data.get("energy_flow"), "lfb")) or 0.0
+    load_from_grid = safe_float_convert(get_energy_flow_value(station_data.get("energy_flow"), "lfg")) or 0.0
+    total_load = load_from_pv + load_from_battery + load_from_grid
+    if total_load <= 0:
+        return None
+    return round((1 - (load_from_grid / total_load)) * 100, 2)
+
+
 @dataclass
 class HoymilesSensorDescription(SensorEntityDescription):
-    """Class describing Hoymiles sensor entities."""
+    """Declarative description for station or aggregate sensors."""
 
     value_fn: Callable[[dict[str, Any]], StateType] | None = None
-    available_fn: Callable[[dict[str, Any]], bool] | None = None
+    exists_fn: Callable[[dict[str, Any]], bool] | None = None
+    device_info_fn: Callable[[str, str, dict[str, Any]], dict[str, Any]] | None = None
 
 
-SENSORS = [
+STATION_SENSORS: list[HoymilesSensorDescription] = [
     HoymilesSensorDescription(
         key="pv_power",
         name="PV Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: safe_float_convert(data.get("real_time_data", {}).get("real_power")),
     ),
     HoymilesSensorDescription(
@@ -136,9 +214,8 @@ SENSORS = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: safe_float_convert(
-            data.get("real_time_data", {}).get("reflux_station_data", {}).get("grid_power")
-        ),
+        suggested_display_precision=2,
+        value_fn=lambda data: safe_float_convert(get_reflux_data(data).get("grid_power")),
     ),
     HoymilesSensorDescription(
         key="load_power",
@@ -146,9 +223,8 @@ SENSORS = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: safe_float_convert(
-            data.get("real_time_data", {}).get("reflux_station_data", {}).get("load_power")
-        ),
+        suggested_display_precision=2,
+        value_fn=lambda data: safe_float_convert(get_reflux_data(data).get("load_power")),
     ),
     HoymilesSensorDescription(
         key="battery_power",
@@ -156,15 +232,17 @@ SENSORS = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: safe_float_convert(
-            data.get("real_time_data", {}).get("reflux_station_data", {}).get("bms_power")
-        ),
-        available_fn=has_battery_telemetry,
+        suggested_display_precision=2,
+        exists_fn=has_battery_telemetry,
+        device_info_fn=get_battery_device_info,
+        value_fn=lambda data: safe_float_convert(get_reflux_data(data).get("bms_power")),
     ),
     HoymilesSensorDescription(
         key="battery_flow_direction",
         name="Battery Flow Direction",
         icon="mdi:battery-charging",
+        exists_fn=has_battery_telemetry,
+        device_info_fn=get_battery_device_info,
         value_fn=lambda data: (
             "discharging"
             if is_battery_charging(data) is False
@@ -172,7 +250,6 @@ SENSORS = [
             if is_battery_charging(data) is True
             else "unknown"
         ),
-        available_fn=has_battery_telemetry,
     ),
     HoymilesSensorDescription(
         key="battery_soc",
@@ -180,10 +257,9 @@ SENSORS = [
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: safe_int_convert(
-            data.get("real_time_data", {}).get("reflux_station_data", {}).get("bms_soc")
-        ),
-        available_fn=has_battery_telemetry,
+        exists_fn=has_battery_telemetry,
+        device_info_fn=get_battery_device_info,
+        value_fn=lambda data: safe_int_convert(get_reflux_data(data).get("bms_soc")),
     ),
     HoymilesSensorDescription(
         key="co2_emission_reduction",
@@ -191,7 +267,7 @@ SENSORS = [
         native_unit_of_measurement=UnitOfMass.GRAMS,
         device_class=SensorDeviceClass.WEIGHT,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: safe_int_convert(data.get("real_time_data", {}).get("co2_emission_reduction")),
+        value_fn=lambda data: safe_float_convert(data.get("real_time_data", {}).get("co2_emission_reduction")),
     ),
     HoymilesSensorDescription(
         key="plant_tree",
@@ -236,9 +312,7 @@ SENSORS = [
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: safe_int_convert(
-            data.get("real_time_data", {}).get("reflux_station_data", {}).get("pv_to_load_eq")
-        ),
+        value_fn=lambda data: safe_int_convert(get_reflux_data(data).get("pv_to_load_eq")),
     ),
     HoymilesSensorDescription(
         key="grid_import_energy_today",
@@ -246,9 +320,7 @@ SENSORS = [
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: safe_int_convert(
-            data.get("real_time_data", {}).get("reflux_station_data", {}).get("meter_b_in_eq")
-        ),
+        value_fn=lambda data: safe_int_convert(get_reflux_data(data).get("meter_b_in_eq")),
     ),
     HoymilesSensorDescription(
         key="grid_export_energy_today",
@@ -256,9 +328,7 @@ SENSORS = [
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: safe_int_convert(
-            data.get("real_time_data", {}).get("reflux_station_data", {}).get("meter_b_out_eq")
-        ),
+        value_fn=lambda data: safe_int_convert(get_reflux_data(data).get("meter_b_out_eq")),
     ),
     HoymilesSensorDescription(
         key="battery_charge_energy_today",
@@ -266,10 +336,9 @@ SENSORS = [
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: safe_int_convert(
-            data.get("real_time_data", {}).get("reflux_station_data", {}).get("bms_in_eq")
-        ),
-        available_fn=has_battery_telemetry,
+        exists_fn=has_battery_telemetry,
+        device_info_fn=get_battery_device_info,
+        value_fn=lambda data: safe_int_convert(get_reflux_data(data).get("bms_in_eq")),
     ),
     HoymilesSensorDescription(
         key="battery_discharge_energy_today",
@@ -277,10 +346,9 @@ SENSORS = [
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: safe_int_convert(
-            data.get("real_time_data", {}).get("reflux_station_data", {}).get("bms_out_eq")
-        ),
-        available_fn=has_battery_telemetry,
+        exists_fn=has_battery_telemetry,
+        device_info_fn=get_battery_device_info,
+        value_fn=lambda data: safe_int_convert(get_reflux_data(data).get("bms_out_eq")),
     ),
     HoymilesSensorDescription(
         key="total_consumption_today",
@@ -288,9 +356,7 @@ SENSORS = [
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: safe_int_convert(
-            data.get("real_time_data", {}).get("reflux_station_data", {}).get("use_eq_total")
-        ),
+        value_fn=lambda data: safe_int_convert(get_reflux_data(data).get("use_eq_total")),
     ),
     HoymilesSensorDescription(
         key="grid_import_total",
@@ -298,9 +364,7 @@ SENSORS = [
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: safe_int_convert(
-            data.get("real_time_data", {}).get("reflux_station_data", {}).get("mb_in_eq", {}).get("total_eq")
-        ),
+        value_fn=lambda data: get_nested_energy_total(data, "mb_in_eq", "total_eq"),
     ),
     HoymilesSensorDescription(
         key="grid_export_total",
@@ -308,17 +372,222 @@ SENSORS = [
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: safe_int_convert(
-            data.get("real_time_data", {}).get("reflux_station_data", {}).get("mb_out_eq", {}).get("total_eq")
+        value_fn=lambda data: get_nested_energy_total(data, "mb_out_eq", "total_eq"),
+    ),
+    HoymilesSensorDescription(
+        key="grid_import_month",
+        name="Grid Import Month",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: get_nested_energy_total(data, "mb_in_eq", "month_eq"),
+    ),
+    HoymilesSensorDescription(
+        key="grid_import_year",
+        name="Grid Import Year",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: get_nested_energy_total(data, "mb_in_eq", "year_eq"),
+    ),
+    HoymilesSensorDescription(
+        key="grid_export_month",
+        name="Grid Export Month",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: get_nested_energy_total(data, "mb_out_eq", "month_eq"),
+    ),
+    HoymilesSensorDescription(
+        key="grid_export_year",
+        name="Grid Export Year",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: get_nested_energy_total(data, "mb_out_eq", "year_eq"),
+    ),
+    HoymilesSensorDescription(
+        key="pv_to_battery_today",
+        name="PV to Battery Today",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        exists_fn=has_energy_flow,
+        value_fn=lambda data: safe_float_convert(get_energy_flow_value(data.get("energy_flow"), "p2b")),
+    ),
+    HoymilesSensorDescription(
+        key="pv_to_grid_today",
+        name="PV to Grid Today",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        exists_fn=has_energy_flow,
+        value_fn=lambda data: safe_float_convert(get_energy_flow_value(data.get("energy_flow"), "p2g")),
+    ),
+    HoymilesSensorDescription(
+        key="pv_to_load_today",
+        name="PV to Load Today",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        exists_fn=has_energy_flow,
+        value_fn=lambda data: safe_float_convert(get_energy_flow_value(data.get("energy_flow"), "p2l")),
+    ),
+    HoymilesSensorDescription(
+        key="load_from_pv",
+        name="Load from PV",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        exists_fn=has_energy_flow,
+        value_fn=lambda data: safe_float_convert(get_energy_flow_value(data.get("energy_flow"), "lfp")),
+    ),
+    HoymilesSensorDescription(
+        key="load_from_battery",
+        name="Load from Battery",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        exists_fn=has_energy_flow,
+        value_fn=lambda data: safe_float_convert(get_energy_flow_value(data.get("energy_flow"), "lfb")),
+    ),
+    HoymilesSensorDescription(
+        key="load_from_grid",
+        name="Load from Grid",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        exists_fn=has_energy_flow,
+        value_fn=lambda data: safe_float_convert(get_energy_flow_value(data.get("energy_flow"), "lfg")),
+    ),
+    HoymilesSensorDescription(
+        key="ev_charger_power",
+        name="EV Charger Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        exists_fn=lambda data: safe_float_convert(get_reflux_data(data).get("pile_power")) is not None,
+        value_fn=lambda data: safe_float_convert(get_reflux_data(data).get("pile_power")),
+    ),
+    HoymilesSensorDescription(
+        key="self_consumption_rate",
+        name="Self Consumption Rate",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        exists_fn=has_energy_flow,
+        value_fn=compute_self_consumption_rate,
+    ),
+    HoymilesSensorDescription(
+        key="self_sufficiency_rate",
+        name="Self Sufficiency Rate",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        exists_fn=has_energy_flow,
+        value_fn=compute_self_sufficiency_rate,
+    ),
+    HoymilesSensorDescription(
+        key="electricity_buy_price",
+        name="Electricity Buy Price",
+        exists_fn=has_eps_settings,
+        suggested_display_precision=4,
+        value_fn=lambda data: safe_float_convert(data.get("eps_settings", {}).get("details", {}).get("p")),
+    ),
+    HoymilesSensorDescription(
+        key="electricity_sell_price",
+        name="Electricity Sell Price",
+        exists_fn=has_eps_settings,
+        suggested_display_precision=4,
+        value_fn=lambda data: safe_float_convert(data.get("eps_settings", {}).get("details", {}).get("sep")),
+    ),
+    HoymilesSensorDescription(
+        key="today_profit",
+        name="Today's Profit",
+        exists_fn=has_eps_profit,
+        suggested_display_precision=3,
+        value_fn=lambda data: safe_float_convert(data.get("eps_profit", {}).get("today_profit")),
+    ),
+    HoymilesSensorDescription(
+        key="monthly_profit",
+        name="Monthly Profit",
+        exists_fn=has_eps_profit,
+        suggested_display_precision=3,
+        value_fn=lambda data: safe_float_convert(data.get("eps_profit", {}).get("monthly_profit")),
+    ),
+    HoymilesSensorDescription(
+        key="yearly_profit",
+        name="Yearly Profit",
+        exists_fn=has_eps_profit,
+        suggested_display_precision=3,
+        value_fn=lambda data: safe_float_convert(data.get("eps_profit", {}).get("yearly_profit")),
+    ),
+    HoymilesSensorDescription(
+        key="total_profit",
+        name="Total Profit",
+        exists_fn=has_eps_profit,
+        suggested_display_precision=3,
+        value_fn=lambda data: safe_float_convert(data.get("eps_profit", {}).get("total_profit")),
+    ),
+    HoymilesSensorDescription(
+        key="today_spend",
+        name="Today's Spend",
+        exists_fn=has_eps_profit,
+        suggested_display_precision=3,
+        value_fn=lambda data: safe_float_convert(data.get("eps_profit", {}).get("today_spend")),
+    ),
+    HoymilesSensorDescription(
+        key="monthly_spend",
+        name="Monthly Spend",
+        exists_fn=has_eps_profit,
+        suggested_display_precision=3,
+        value_fn=lambda data: safe_float_convert(data.get("eps_profit", {}).get("monthly_spend")),
+    ),
+    HoymilesSensorDescription(
+        key="yearly_spend",
+        name="Yearly Spend",
+        exists_fn=has_eps_profit,
+        suggested_display_precision=3,
+        value_fn=lambda data: safe_float_convert(data.get("eps_profit", {}).get("yearly_spend")),
+    ),
+    HoymilesSensorDescription(
+        key="total_spend",
+        name="Total Spend",
+        exists_fn=has_eps_profit,
+        suggested_display_precision=3,
+        value_fn=lambda data: safe_float_convert(data.get("eps_profit", {}).get("total_spend")),
+    ),
+    HoymilesSensorDescription(
+        key="ai_status",
+        name="AI Mode Status",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        exists_fn=lambda data: bool(data.get("capabilities", {}).get("ai_available")),
+        value_fn=lambda data: "active" if data.get("ai_status", {}).get("ai") == 1 else "inactive",
+    ),
+    HoymilesSensorDescription(
+        key="ai_compound_mode",
+        name="AI Compound Mode",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        exists_fn=lambda data: bool(data.get("capabilities", {}).get("ai_available")),
+        value_fn=lambda data: data.get("ai_status", {}).get("compound_mode"),
+    ),
+    HoymilesSensorDescription(
+        key="firmware_status",
+        name="Firmware Status",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        exists_fn=lambda data: bool(data.get("capabilities", {}).get("firmware_available")),
+        value_fn=lambda data: (
+            "update_available"
+            if safe_int_convert(data.get("firmware", {}).get("upgrade")) not in (None, 0)
+            else "up_to_date"
         ),
     ),
     HoymilesSensorDescription(
         key="reported_inverter_count",
         name="Reported Inverter Count",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: safe_int_convert(
-            data.get("real_time_data", {}).get("reflux_station_data", {}).get("inv_num")
-        ),
+        value_fn=lambda data: safe_int_convert(get_reflux_data(data).get("inv_num")),
     ),
     HoymilesSensorDescription(
         key="last_update_time",
@@ -334,8 +603,7 @@ SENSORS = [
         value_fn=lambda data: (
             "readable"
             if battery_settings_readable(data.get("battery_settings"))
-            else data.get("battery_settings", {}).get("error_message")
-            or "unavailable"
+            else data.get("battery_settings", {}).get("error_message") or "unavailable"
         ),
     ),
     HoymilesSensorDescription(
@@ -344,11 +612,28 @@ SENSORS = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: safe_float_convert(
-            get_pv_indicator_value(data.get("pv_indicators", {}), "pv_p_total")
-        ),
-        available_fn=lambda data: has_pv_indicator(data, "pv_p_total"),
+        suggested_display_precision=2,
+        exists_fn=lambda data: has_pv_indicator(data, "pv_p_total"),
+        device_info_fn=get_inverter_device_info,
+        value_fn=lambda data: safe_float_convert(get_pv_indicator_value(data.get("pv_indicators", {}), "pv_p_total")),
     ),
+]
+
+GRID_INDICATOR_SPECS = [
+    ("grid_frequency", "Grid Frequency", "frequency", UnitOfFrequency.HERTZ, SensorDeviceClass.FREQUENCY, 2),
+    ("grid_voltage_l1", "Grid Voltage L1", "v_a", UnitOfElectricPotential.VOLT, SensorDeviceClass.VOLTAGE, 1),
+    ("grid_voltage_l2", "Grid Voltage L2", "v_b", UnitOfElectricPotential.VOLT, SensorDeviceClass.VOLTAGE, 1),
+    ("grid_voltage_l3", "Grid Voltage L3", "v_c", UnitOfElectricPotential.VOLT, SensorDeviceClass.VOLTAGE, 1),
+    ("grid_current_l1", "Grid Current L1", "i_a", UnitOfElectricCurrent.AMPERE, SensorDeviceClass.CURRENT, 2),
+    ("grid_current_l2", "Grid Current L2", "i_b", UnitOfElectricCurrent.AMPERE, SensorDeviceClass.CURRENT, 2),
+    ("grid_current_l3", "Grid Current L3", "i_c", UnitOfElectricCurrent.AMPERE, SensorDeviceClass.CURRENT, 2),
+    ("grid_power_l1", "Grid Power L1", "p_a", UnitOfPower.WATT, SensorDeviceClass.POWER, 2),
+    ("grid_power_l2", "Grid Power L2", "p_b", UnitOfPower.WATT, SensorDeviceClass.POWER, 2),
+    ("grid_power_l3", "Grid Power L3", "p_c", UnitOfPower.WATT, SensorDeviceClass.POWER, 2),
+    ("grid_power_factor_l1", "Grid Power Factor L1", "pf_a", None, None, 3),
+    ("grid_power_factor_l2", "Grid Power Factor L2", "pf_b", None, None, 3),
+    ("grid_power_factor_l3", "Grid Power Factor L3", "pf_c", None, None, 3),
+    ("grid_state", "Grid State", "grid_state", None, None, None),
 ]
 
 
@@ -364,11 +649,13 @@ async def async_setup_entry(
 
     entities: list[SensorEntity] = []
     for station_id, station_name in stations.items():
-        station_data = coordinator.data.get(station_id, {}) if coordinator.data else {}
+        station_data = get_station_data(coordinator, station_id)
 
-        for description in SENSORS:
+        for description in STATION_SENSORS:
+            if description.exists_fn and not description.exists_fn(station_data):
+                continue
             entities.append(
-                HoymilesSensor(
+                HoymilesAggregateSensor(
                     coordinator=coordinator,
                     description=description,
                     station_id=station_id,
@@ -377,13 +664,8 @@ async def async_setup_entry(
             )
 
         if battery_settings_readable(station_data.get("battery_settings", {})):
-            entities.append(
-                HoymilesBatteryModeSensor(
-                    coordinator=coordinator,
-                    station_id=station_id,
-                    station_name=station_name,
-                )
-            )
+            entities.append(HoymilesBatteryModeSensor(coordinator, station_id, station_name))
+
         if station_data.get("schedule_editor", {}).get("available_modes"):
             entities.extend(
                 [
@@ -400,26 +682,185 @@ async def async_setup_entry(
         for channel in discover_pv_channels(station_data.get("pv_indicators", {})):
             entities.extend(
                 [
-                    HoymilesPVChannelSensor(
-                        coordinator=coordinator,
-                        station_id=station_id,
-                        station_name=station_name,
-                        channel=channel,
-                        metric="v",
+                    HoymilesPVChannelSensor(coordinator, station_id, station_name, channel, "v"),
+                    HoymilesPVChannelSensor(coordinator, station_id, station_name, channel, "i"),
+                    HoymilesPVChannelSensor(coordinator, station_id, station_name, channel, "p"),
+                ]
+            )
+
+        for entity_key, label, indicator_key, unit, device_class, precision in GRID_INDICATOR_SPECS:
+            if has_grid_indicator(station_data, indicator_key):
+                entities.append(
+                    HoymilesGridIndicatorSensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        entity_key,
+                        label,
+                        indicator_key,
+                        unit,
+                        device_class,
+                        precision,
+                    )
+                )
+
+        for inverter in station_data.get("devices", {}).get("inverters", []):
+            entities.extend(
+                [
+                    HoymilesDeviceAttributeSensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        "inverters",
+                        inverter,
+                        "model",
+                        "Inverter Model",
+                        "model_no",
+                        build_inverter_device_info,
                     ),
-                    HoymilesPVChannelSensor(
-                        coordinator=coordinator,
-                        station_id=station_id,
-                        station_name=station_name,
-                        channel=channel,
-                        metric="i",
+                    HoymilesDeviceAttributeSensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        "inverters",
+                        inverter,
+                        "firmware",
+                        "Inverter Firmware Version",
+                        "soft_ver",
+                        build_inverter_device_info,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        enabled_default=False,
                     ),
-                    HoymilesPVChannelSensor(
-                        coordinator=coordinator,
-                        station_id=station_id,
-                        station_name=station_name,
-                        channel=channel,
-                        metric="p",
+                    HoymilesDeviceAttributeSensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        "inverters",
+                        inverter,
+                        "hardware",
+                        "Inverter Hardware Version",
+                        "hard_ver",
+                        build_inverter_device_info,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        enabled_default=False,
+                    ),
+                ]
+            )
+
+        for battery in station_data.get("devices", {}).get("batteries", []):
+            entities.extend(
+                [
+                    HoymilesDeviceAttributeSensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        "batteries",
+                        battery,
+                        "capacity",
+                        "Battery Capacity",
+                        "cap",
+                        build_battery_device_info,
+                    ),
+                    HoymilesDeviceAttributeSensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        "batteries",
+                        battery,
+                        "bms_type",
+                        "Battery BMS Type",
+                        "bms_type",
+                        build_battery_device_info,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                    HoymilesDeviceAttributeSensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        "batteries",
+                        battery,
+                        "firmware",
+                        "Battery Firmware Version",
+                        "soft_ver",
+                        build_battery_device_info,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        enabled_default=False,
+                    ),
+                    HoymilesDeviceAttributeSensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        "batteries",
+                        battery,
+                        "hardware",
+                        "Battery Hardware Version",
+                        "hard_ver",
+                        build_battery_device_info,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        enabled_default=False,
+                    ),
+                ]
+            )
+
+        for meter in station_data.get("devices", {}).get("meters", []):
+            entities.extend(
+                [
+                    HoymilesDeviceAttributeSensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        "meters",
+                        meter,
+                        "location",
+                        "Meter Location",
+                        "location",
+                        build_meter_device_info,
+                        value_transform=lambda value: METER_LOCATION_NAMES.get(value, str(value)),
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                    HoymilesDeviceAttributeSensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        "meters",
+                        meter,
+                        "ct_gain",
+                        "Meter CT Gain",
+                        "ct_gain",
+                        build_meter_device_info,
+                        value_transform=safe_float_convert,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ]
+            )
+
+        for dtu in station_data.get("devices", {}).get("dtus", []):
+            entities.extend(
+                [
+                    HoymilesDeviceAttributeSensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        "dtus",
+                        dtu,
+                        "serial",
+                        "DTU Serial",
+                        "sn",
+                        build_dtu_device_info,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        enabled_default=False,
+                    ),
+                    HoymilesDeviceAttributeSensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        "dtus",
+                        dtu,
+                        "device_type",
+                        "DTU Device Type",
+                        "type",
+                        build_dtu_device_info,
+                        entity_category=EntityCategory.DIAGNOSTIC,
                     ),
                 ]
             )
@@ -439,20 +880,15 @@ class HoymilesBaseSensor(CoordinatorEntity, SensorEntity):
         """Initialize the shared station fields."""
         super().__init__(coordinator)
         self._station_id = station_id
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, station_id)},
-            "name": station_name,
-            "manufacturer": "Hoymiles",
-            "model": "Solar Inverter System",
-        }
+        self._station_name = station_name
 
     def _get_station_data(self) -> dict[str, Any]:
         """Return the station payload from the coordinator."""
-        return self.coordinator.data.get(self._station_id, {}) if self.coordinator.data else {}
+        return get_station_data(self.coordinator, self._station_id)
 
 
-class HoymilesSensor(HoymilesBaseSensor):
-    """Representation of a generic Hoymiles sensor."""
+class HoymilesAggregateSensor(HoymilesBaseSensor):
+    """Representation of a generic aggregate sensor."""
 
     entity_description: HoymilesSensorDescription
 
@@ -466,8 +902,14 @@ class HoymilesSensor(HoymilesBaseSensor):
         """Initialize the sensor."""
         super().__init__(coordinator, station_id, station_name)
         self.entity_description = description
+        station_data = self._get_station_data()
         self._attr_unique_id = f"{DOMAIN}_{station_id}_{description.key}"
         self._attr_name = f"{station_name} {description.name}"
+        self._attr_device_info = (
+            description.device_info_fn(station_id, station_name, station_data)
+            if description.device_info_fn
+            else get_station_device_info(station_id, station_name, station_data)
+        )
 
     @property
     def native_value(self) -> StateType:
@@ -485,25 +927,21 @@ class HoymilesSensor(HoymilesBaseSensor):
         """Return if entity is available."""
         if not self.coordinator.last_update_success:
             return False
-        if self.entity_description.available_fn:
-            return self.entity_description.available_fn(self._get_station_data())
+        if self.entity_description.exists_fn:
+            return self.entity_description.exists_fn(self._get_station_data())
         return bool(self._get_station_data())
 
 
 class HoymilesBatteryModeSensor(HoymilesBaseSensor):
     """Sensor for displaying the current battery mode."""
 
-    def __init__(
-        self,
-        coordinator: DataUpdateCoordinator,
-        station_id: str,
-        station_name: str,
-    ) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator, station_id: str, station_name: str) -> None:
         """Initialize the battery mode sensor."""
         super().__init__(coordinator, station_id, station_name)
         self._attr_unique_id = f"{DOMAIN}_{station_id}_battery_mode"
         self._attr_name = f"{station_name} Battery Mode Status"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_device_info = get_battery_device_info(station_id, station_name, self._get_station_data())
 
     @property
     def native_value(self) -> str | None:
@@ -517,10 +955,13 @@ class HoymilesBatteryModeSensor(HoymilesBaseSensor):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Expose the supported battery modes for diagnostics."""
-        battery_settings = self._get_station_data().get("battery_settings", {})
+        station_data = self._get_station_data()
+        battery_settings = station_data.get("battery_settings", {})
+        setting_rules = station_data.get("setting_rules", {})
         return {
             "mode_id": battery_settings.get("data", {}).get("mode"),
             "supported_modes": get_supported_modes(battery_settings),
+            "allowed_modes": get_allowed_battery_modes(battery_settings, setting_rules),
             "schedule_modes": get_schedule_modes(battery_settings),
         }
 
@@ -532,13 +973,66 @@ class HoymilesBatteryModeSensor(HoymilesBaseSensor):
         )
 
 
+class HoymilesDeviceAttributeSensor(HoymilesBaseSensor):
+    """Diagnostic sensor for a specific child-device attribute."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        station_id: str,
+        station_name: str,
+        device_kind: str,
+        device: dict[str, Any],
+        entity_key: str,
+        label: str,
+        state_key: str,
+        device_info_builder: Callable[[str, str, dict[str, Any]], dict[str, Any]],
+        *,
+        value_transform: Callable[[Any], Any] | None = None,
+        entity_category: EntityCategory | None = EntityCategory.DIAGNOSTIC,
+        enabled_default: bool = True,
+    ) -> None:
+        """Initialize the device attribute sensor."""
+        super().__init__(coordinator, station_id, station_name)
+        self._device_kind = device_kind
+        self._state_key = state_key
+        self._value_transform = value_transform or (lambda value: value)
+        self._entity_category = entity_category
+        self._match_value = str(device.get("sn") or device.get("id") or "")
+        self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_kind}_{self._match_value}_{entity_key}"
+        self._attr_name = f"{station_name} {label}"
+        self._attr_entity_category = entity_category
+        self._attr_entity_registry_enabled_default = enabled_default
+        self._attr_device_info = device_info_builder(station_id, station_name, device)
+
+    def _get_device(self) -> dict[str, Any] | None:
+        """Return the current matching device payload."""
+        for device in self._get_station_data().get("devices", {}).get(self._device_kind, []):
+            if str(device.get("sn") or device.get("id") or "") == self._match_value:
+                return device
+        return None
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the device attribute value."""
+        device = self._get_device()
+        if not device:
+            return None
+        return self._value_transform(device.get(self._state_key))
+
+    @property
+    def available(self) -> bool:
+        """Return whether the device attribute is available."""
+        return self.coordinator.last_update_success and self._get_device() is not None
+
+
 class HoymilesPVChannelSensor(HoymilesBaseSensor):
     """Dynamic PV channel sensor discovered from indicator keys."""
 
     _METRIC_CONFIG = {
-        "v": ("Voltage", UnitOfElectricPotential.VOLT, SensorDeviceClass.VOLTAGE),
-        "i": ("Current", UnitOfElectricCurrent.AMPERE, SensorDeviceClass.CURRENT),
-        "p": ("Power", UnitOfPower.WATT, SensorDeviceClass.POWER),
+        "v": ("Voltage", UnitOfElectricPotential.VOLT, SensorDeviceClass.VOLTAGE, 1),
+        "i": ("Current", UnitOfElectricCurrent.AMPERE, SensorDeviceClass.CURRENT, 2),
+        "p": ("Power", UnitOfPower.WATT, SensorDeviceClass.POWER, 2),
     }
 
     def __init__(
@@ -551,7 +1045,7 @@ class HoymilesPVChannelSensor(HoymilesBaseSensor):
     ) -> None:
         """Initialize the PV channel sensor."""
         super().__init__(coordinator, station_id, station_name)
-        label, unit, device_class = self._METRIC_CONFIG[metric]
+        label, unit, device_class, precision = self._METRIC_CONFIG[metric]
         self._channel = channel
         self._metric = metric
         self._indicator_key = f"{channel}_pv_{metric}"
@@ -560,24 +1054,60 @@ class HoymilesPVChannelSensor(HoymilesBaseSensor):
         self._attr_native_unit_of_measurement = unit
         self._attr_device_class = device_class
         self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_suggested_display_precision = precision
+        self._attr_device_info = get_inverter_device_info(station_id, station_name, self._get_station_data())
 
     @property
     def native_value(self) -> float | None:
         """Return the current indicator value."""
         return safe_float_convert(
-            get_pv_indicator_value(
-                self._get_station_data().get("pv_indicators", {}),
-                self._indicator_key,
-            )
+            get_pv_indicator_value(self._get_station_data().get("pv_indicators", {}), self._indicator_key)
         )
 
     @property
     def available(self) -> bool:
         """Return whether this PV channel is present in the payload."""
-        return self.coordinator.last_update_success and has_pv_indicator(
-            self._get_station_data(),
-            self._indicator_key,
-        )
+        return self.coordinator.last_update_success and has_pv_indicator(self._get_station_data(), self._indicator_key)
+
+
+class HoymilesGridIndicatorSensor(HoymilesBaseSensor):
+    """Sensor backed by grid indicator payload values."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        station_id: str,
+        station_name: str,
+        entity_key: str,
+        label: str,
+        indicator_key: str,
+        unit,
+        device_class,
+        suggested_display_precision: int | None,
+    ) -> None:
+        """Initialize the grid indicator sensor."""
+        super().__init__(coordinator, station_id, station_name)
+        self._indicator_key = indicator_key
+        self._attr_unique_id = f"{DOMAIN}_{station_id}_{entity_key}"
+        self._attr_name = f"{station_name} {label}"
+        self._attr_native_unit_of_measurement = unit
+        self._attr_device_class = device_class
+        self._attr_state_class = SensorStateClass.MEASUREMENT if unit is not None else None
+        self._attr_suggested_display_precision = suggested_display_precision
+        self._attr_device_info = get_inverter_device_info(station_id, station_name, self._get_station_data())
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the current grid-indicator value."""
+        value = get_indicator_value(self._get_station_data().get("grid_indicators", {}), self._indicator_key)
+        if self._attr_native_unit_of_measurement is None:
+            return value
+        return safe_float_convert(value)
+
+    @property
+    def available(self) -> bool:
+        """Return whether the indicator is present in the payload."""
+        return self.coordinator.last_update_success and has_grid_indicator(self._get_station_data(), self._indicator_key)
 
 
 class HoymilesScheduleEditorModeSensor(HoymilesBaseSensor):
@@ -588,6 +1118,7 @@ class HoymilesScheduleEditorModeSensor(HoymilesBaseSensor):
         self._attr_unique_id = f"{DOMAIN}_{station_id}_schedule_editor_mode_status"
         self._attr_name = f"{station_name} Current Schedule Editor Mode"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_device_info = get_station_device_info(station_id, station_name, self._get_station_data())
 
     @property
     def native_value(self) -> str | None:
@@ -613,6 +1144,7 @@ class HoymilesScheduleSummarySensor(HoymilesBaseSensor):
         self._attr_unique_id = f"{DOMAIN}_{station_id}_{mode_label}_schedule_summary"
         self._attr_name = f"{station_name} {'Economy' if mode == 2 else 'Time of Use'} Schedule Summary"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_device_info = get_station_device_info(station_id, station_name, self._get_station_data())
 
     @property
     def native_value(self) -> str | None:
@@ -635,6 +1167,7 @@ class HoymilesScheduleCountSensor(HoymilesBaseSensor):
         self._attr_unique_id = f"{DOMAIN}_{station_id}_{mode_label}_schedule_count"
         self._attr_name = f"{station_name} {'Economy' if mode == 2 else 'Time of Use'} Schedule Count"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_device_info = get_station_device_info(station_id, station_name, self._get_station_data())
 
     @property
     def native_value(self) -> int:
@@ -655,6 +1188,7 @@ class HoymilesScheduleEditorValidationSensor(HoymilesBaseSensor):
         self._attr_unique_id = f"{DOMAIN}_{station_id}_schedule_editor_validation"
         self._attr_name = f"{station_name} Schedule Editor Validation Status"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_device_info = get_station_device_info(station_id, station_name, self._get_station_data())
 
     @property
     def native_value(self) -> str:
@@ -686,6 +1220,7 @@ class HoymilesScheduleEditorDirtySensor(HoymilesBaseSensor):
         self._attr_unique_id = f"{DOMAIN}_{station_id}_schedule_editor_dirty"
         self._attr_name = f"{station_name} Schedule Editor Dirty State"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_device_info = get_station_device_info(station_id, station_name, self._get_station_data())
 
     @property
     def native_value(self) -> str:

--- a/custom_components/hoymiles_cloud/services.yaml
+++ b/custom_components/hoymiles_cloud/services.yaml
@@ -1,6 +1,6 @@
 set_battery_mode:
   name: Set battery mode
-  description: Activate a Hoymiles battery mode for a station.
+  description: Activate a Hoymiles battery mode for a station using the direct battery-config write path.
   fields:
     station_id:
       name: Station ID
@@ -29,7 +29,8 @@ set_battery_mode_settings:
   name: Set battery mode settings
   description: >
     Update the structured payload for a Hoymiles battery mode and activate that mode.
-    This is intended for advanced settings such as Economy and Time of Use schedules.
+    This uses the direct battery-config write path and is intended for advanced settings
+    such as Economy and Time of Use schedules.
   fields:
     station_id:
       name: Station ID

--- a/custom_components/hoymiles_cloud/switch.py
+++ b/custom_components/hoymiles_cloud/switch.py
@@ -1,0 +1,93 @@
+"""Switch platform for Hoymiles Cloud integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
+
+from .const import DOMAIN
+from .data import relay_settings_readable, relay_settings_writable, relay_settings_enabled
+from .device import build_station_device_info
+from .hoymiles_api import HoymilesAPI
+
+
+def get_station_data(coordinator: DataUpdateCoordinator, station_id: str) -> dict[str, Any]:
+    """Return one station payload."""
+    return coordinator.data.get(station_id, {}) if coordinator.data else {}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Hoymiles Cloud switches."""
+    runtime_data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = runtime_data["coordinator"]
+    stations = runtime_data["stations"]
+    api = runtime_data["api"]
+
+    entities: list[SwitchEntity] = []
+    for station_id, station_name in stations.items():
+        station_data = get_station_data(coordinator, station_id)
+        if relay_settings_readable(station_data.get("relay_settings")):
+            entities.append(HoymilesRelaySwitch(coordinator, api, station_id, station_name))
+
+    async_add_entities(entities)
+
+
+class HoymilesRelaySwitch(CoordinatorEntity, SwitchEntity):
+    """Switch for enabling or disabling relay / dry-contact automation."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        api: HoymilesAPI,
+        station_id: str,
+        station_name: str,
+    ) -> None:
+        """Initialize the relay switch."""
+        super().__init__(coordinator)
+        self._api = api
+        self._station_id = station_id
+        self._attr_unique_id = f"{DOMAIN}_{station_id}_relay_enabled"
+        self._attr_name = f"{station_name} Relay Automation"
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_device_info = build_station_device_info(
+            station_id,
+            station_name,
+            get_station_data(coordinator, station_id).get("station_info"),
+        )
+
+    def _get_station_data(self) -> dict[str, Any]:
+        """Return the current station payload."""
+        return get_station_data(self.coordinator, self._station_id)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether relay automation appears enabled."""
+        return relay_settings_enabled(self._get_station_data().get("relay_settings"))
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable relay automation."""
+        if await self._api.set_relay_enabled(self._station_id, True):
+            await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable relay automation."""
+        if await self._api.set_relay_enabled(self._station_id, False):
+            await self.coordinator.async_request_refresh()
+
+    @property
+    def available(self) -> bool:
+        """Return whether the switch is available."""
+        if not self.coordinator.last_update_success:
+            return False
+        relay_settings = self._get_station_data().get("relay_settings")
+        return relay_settings_readable(relay_settings) and relay_settings_writable(relay_settings)

--- a/custom_components/hoymiles_cloud/translations/en.json
+++ b/custom_components/hoymiles_cloud/translations/en.json
@@ -6,9 +6,23 @@
         "description": "Enter your Hoymiles Cloud credentials",
         "data": {
           "username": "Username (Email)",
-          "password": "Password"
+          "password": "Password",
+          "auth_mode": "Authentication mode",
+          "app_version": "Override app version (optional)"
         }
+      },
+      "confirm": {
+        "title": "Confirm Stations",
+        "description": "Authentication succeeded. The following stations were discovered: {stations}"
       }
+    },
+    "progress": {
+      "confirm": {
+        "description": "Verifying credentials and discovering stations"
+      }
+    },
+    "abort": {
+      "already_configured": "Account already configured"
     },
     "error": {
       "cannot_connect": "Failed to connect to Hoymiles Cloud",
@@ -19,8 +33,16 @@
       "no_accessible_stations": "Authentication succeeded, but no accessible stations were returned for this account",
       "unknown": "Unexpected error"
     },
-    "abort": {
-      "already_configured": "Account already configured"
+    "selector": {
+      "auth_mode": {
+        "options": {
+          "auto": "Auto-detect",
+          "web_v3": "S-Miles Cloud Web",
+          "installer_v3": "S-Miles Installer",
+          "home_v3": "S-Miles Home",
+          "legacy_v0": "Legacy v0"
+        }
+      }
     }
   },
   "options": {
@@ -29,7 +51,10 @@
         "title": "Hoymiles Cloud Options",
         "description": "Configure the integration options",
         "data": {
-          "scan_interval": "Data update interval (seconds)"
+          "scan_interval": "Data update interval (seconds)",
+          "fetch_grid_indicators": "Fetch 3-phase grid indicators",
+          "fetch_energy_flow": "Fetch daily energy-flow statistics",
+          "fetch_eps_profit": "Fetch EPS profit and spend statistics"
         }
       }
     }

--- a/custom_components/hoymiles_cloud/translations/en.json
+++ b/custom_components/hoymiles_cloud/translations/en.json
@@ -28,7 +28,7 @@
       "cannot_connect": "Failed to connect to Hoymiles Cloud",
       "invalid_auth": "Invalid authentication",
       "app_update_required": "Hoymiles rejected the login because the client version is too old",
-      "s_miles_home_required": "This account appears to require a different Hoymiles login type (for example S-Miles Home)",
+      "s_miles_home_required": "This is a consumer S-Miles Home account (typical for MS-A2 balcony storage). It uses a different Hoymiles backend that this integration does not support yet, so changing the authentication mode will not help. See https://github.com/Philra94/homeassistant-hoymiles-cloud/issues/30 if you can help capture the app's login details.",
       "no_stations": "No stations found for this account",
       "no_accessible_stations": "Authentication succeeded, but no accessible stations were returned for this account",
       "unknown": "Unexpected error"
@@ -39,7 +39,7 @@
           "auto": "Auto-detect",
           "web_v3": "S-Miles Cloud Web",
           "installer_v3": "S-Miles Installer",
-          "home_v3": "S-Miles Home",
+          "home_v3": "S-Miles Home (not yet supported)",
           "legacy_v0": "Legacy v0"
         }
       }

--- a/scripts/test_login_flow.py
+++ b/scripts/test_login_flow.py
@@ -90,6 +90,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Override the app version used for installer/home auth attempts.",
     )
     parser.add_argument(
+        "--auth-base-url",
+        default=None,
+        help=(
+            "Advanced: override the auth backend host (e.g. a candidate S-Miles "
+            "Home consumer backend discovered via a network trace), such as "
+            "https://example.hoymiles.com."
+        ),
+    )
+    parser.add_argument(
+        "--dump-raw",
+        action="store_true",
+        help=(
+            "Print the sanitized raw pre-inspection request/response for the "
+            "selected profile/host, formatted for pasting into a GitHub issue."
+        ),
+    )
+    parser.add_argument(
         "--mobile-app-version",
         dest="app_version",
         default=None,
@@ -128,6 +145,65 @@ def redact_token(token: str | None) -> str:
     return f"{token[:8]}...{token[-4:]}"
 
 
+SENSITIVE_KEYS = ("a", "ch", "token", "salt", "password", "pwd")
+
+
+def sanitize_payload(value: Any) -> Any:
+    """Recursively mask password/salt/token-derived values for safe sharing."""
+    if isinstance(value, dict):
+        return {
+            key: ("<redacted>" if key.lower() in SENSITIVE_KEYS else sanitize_payload(val))
+            for key, val in value.items()
+        }
+    if isinstance(value, list):
+        return [sanitize_payload(item) for item in value]
+    return value
+
+
+def sanitize_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Mask any auth-bearing headers before printing."""
+    masked = {}
+    for key, val in headers.items():
+        masked[key] = "<redacted>" if key.lower() in ("authorization", "cookie") else val
+    return masked
+
+
+async def dump_raw_pre_insp(api: Any, session: "aiohttp.ClientSession", auth_mode: str) -> None:
+    """Print the sanitized raw pre-inspection request/response for diagnostics.
+
+    The pre-inspection call only sends the username, so its request body is safe
+    to share once the email is masked. Its response reveals the salt field ``a``
+    (or its absence), which is what distinguishes Hoymiles account families.
+    """
+    const = sys.modules[f"{PACKAGE_NAME}.const"]
+    profile = const.AUTH_MODE_TO_PROFILE.get(auth_mode, const.CLIENT_PROFILE_WEB)
+    url = api._auth_url(profile, const.AUTH_PATH_PRE_INSP_V3)  # noqa: SLF001
+    print("\n=== RAW pre-insp dump (safe to paste into a GitHub issue) ===")
+    if not url:
+        print(f"Profile '{profile}' has no configured backend host (base_url is None).")
+        print("Use --auth-base-url to point at a candidate host.")
+        return
+
+    headers = api._json_headers(client_profile=profile)  # noqa: SLF001
+    print(f"POST {url}")
+    print("Request headers:")
+    print(json.dumps(sanitize_headers(headers), indent=2, sort_keys=True))
+    print('Request body: {"u": "<redacted-email>"}')
+    try:
+        async with session.post(url, headers=headers, json={"u": api._username}) as response:  # noqa: SLF001
+            body = await response.json(content_type=None)
+            print(f"Response status (HTTP): {response.status}")
+            print("Response body:")
+            print(json.dumps(sanitize_payload(body), indent=2, sort_keys=True))
+    except Exception as err:  # noqa: BLE001
+        print(f"Pre-insp request failed: {err}")
+    print(
+        "\nNote: the follow-up /auth/login body is {u, ch, n} where 'ch' is a "
+        "password-derived hash (redacted above). Share the login HTTP status and "
+        "message from the attempt summary instead.\n"
+    )
+
+
 def summarize_user(user: dict[str, Any]) -> dict[str, Any]:
     """Return a small, stable subset of user data."""
     interesting_keys = (
@@ -154,9 +230,19 @@ async def main() -> int:
     print(f"Username: {username}")
     print(f"Auth mode: {args.auth_mode}")
 
+    if args.auth_base_url:
+        print(f"Auth base URL override: {args.auth_base_url}")
+
     async with aiohttp.ClientSession() as session:
         api = HoymilesAPI(session, username, password)
-        api.configure_auth(auth_mode=args.auth_mode, app_version=args.app_version)
+        api.configure_auth(
+            auth_mode=args.auth_mode,
+            app_version=args.app_version,
+            auth_base_url=args.auth_base_url,
+        )
+
+        if args.dump_raw:
+            await dump_raw_pre_insp(api, session, args.auth_mode)
 
         if args.try_matrix:
             matrix = [
@@ -168,7 +254,11 @@ async def main() -> int:
             overall_success = False
             print("Trying auth matrix...")
             for auth_mode, app_version in matrix:
-                api.configure_auth(auth_mode=auth_mode, app_version=app_version)
+                api.configure_auth(
+                    auth_mode=auth_mode,
+                    app_version=app_version,
+                    auth_base_url=args.auth_base_url,
+                )
                 authenticated = await api.authenticate()
                 status = "OK" if authenticated else "FAILED"
                 detail = api.auth_method if authenticated else api.last_auth_attempt_summary

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,11 +3,14 @@ from tests.module_loader import load_integration_module
 
 data_module = load_integration_module("data")
 build_empty_battery_settings = data_module.build_empty_battery_settings
+build_empty_relay_settings = data_module.build_empty_relay_settings
 build_schedule_editor_state = data_module.build_schedule_editor_state
 build_schedule_payload_from_draft = data_module.build_schedule_payload_from_draft
 build_station_capabilities = data_module.build_station_capabilities
 discover_pv_channels = data_module.discover_pv_channels
+get_allowed_battery_modes = data_module.get_allowed_battery_modes
 get_schedule_modes = data_module.get_schedule_modes
+relay_settings_enabled = data_module.relay_settings_enabled
 validate_schedule_draft = data_module.validate_schedule_draft
 
 
@@ -37,12 +40,25 @@ def test_build_station_capabilities_keeps_battery_telemetry_separate() -> None:
             status="3",
             message="No Permission.",
         ),
+        relay_settings=build_empty_relay_settings(
+            readable=True,
+            writable=True,
+        ),
+        devices={"batteries": [{"sn": "BAT-1"}], "meters": [{"location": 2}], "dtus": [], "inverters": []},
+        setting_rules={"ctl_mode_set": [1, 8]},
+        eps_settings={"details": {"p": "0.31", "sep": "0.11"}},
+        ai_status={"ai": 1},
         microinverters_data={},
     )
 
     assert capabilities["battery_telemetry"] is True
     assert capabilities["battery_settings_readable"] is False
     assert capabilities["battery_settings_writable"] is False
+    assert capabilities["relay_settings_readable"] is True
+    assert capabilities["has_battery"] is True
+    assert capabilities["has_meter"] is True
+    assert capabilities["eps_available"] is True
+    assert capabilities["ai_available"] is True
     assert capabilities["pv_channels"] == [1]
 
 
@@ -189,3 +205,25 @@ def test_validate_schedule_draft_reports_invalid_times() -> None:
 
     assert errors
     assert "invalid cs_time" in errors[0]
+
+
+def test_get_allowed_battery_modes_honors_ctl_mode_set() -> None:
+    """Station rules should restrict selectable battery modes when present."""
+    battery_settings = build_empty_battery_settings(readable=True, writable=True)
+    battery_settings["available_modes"] = [1, 2, 5, 8]
+
+    assert get_allowed_battery_modes(battery_settings, {"ctl_mode_set": [2, 8]}) == [2, 8]
+
+
+def test_relay_settings_enabled_detects_nested_modes() -> None:
+    """Relay enablement should inspect nested k_2 / k_3 modes."""
+    relay_settings = build_empty_relay_settings(readable=True, writable=True)
+    relay_settings["data"] = {
+        "mode": 0,
+        "data": {
+            "k_2": {"mode": 2},
+            "k_3": {"mode": 0},
+        },
+    }
+
+    assert relay_settings_enabled(relay_settings) is True

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,31 @@
+"""Tests for device helpers."""
+
+from tests.module_loader import load_integration_module
+
+device_module = load_integration_module("device")
+
+
+def test_build_station_device_info_uses_energy_storage_model() -> None:
+    """Energy-storage stations should surface a clearer top-level device model."""
+    info = device_module.build_station_device_info(
+        "123",
+        "Roof",
+        {"classify": 4, "name": "Roof Station"},
+    )
+
+    assert info["name"] == "Roof Station"
+    assert info["model"] == "Energy Storage Plant"
+    assert ("hoymiles_cloud", "123") in info["identifiers"]
+
+
+def test_build_inverter_device_info_links_back_to_station() -> None:
+    """Child devices should use via_device to connect to the station device."""
+    info = device_module.build_inverter_device_info(
+        "123",
+        "Roof",
+        {"sn": "INV-1", "model_no": "HYS-3.6", "soft_ver": "1.2.3", "hard_ver": "A"},
+    )
+
+    assert info["via_device"] == ("hoymiles_cloud", "123")
+    assert ("hoymiles_cloud", "inverter_INV-1") in info["identifiers"]
+    assert info["sw_version"] == "1.2.3"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,64 @@
+"""Tests for diagnostics helpers."""
+
+import asyncio
+from types import SimpleNamespace
+
+from tests.module_loader import load_integration_module
+
+diagnostics_module = load_integration_module("diagnostics")
+
+
+class FakeCoordinator:
+    """Minimal coordinator stand-in for diagnostics tests."""
+
+    def __init__(self, data):
+        self.data = data
+        self.last_update_success = True
+
+
+class FakeAPI:
+    """Minimal API stand-in for diagnostics tests."""
+
+    auth_method = "home_v3:sha256_v3"
+    last_auth_attempt = "home_v3"
+    last_auth_status = None
+    last_auth_message = None
+    last_auth_attempt_summary = "home_v3[home/2.8.0] (sha256_v3) -> ok"
+
+
+def test_async_get_config_entry_diagnostics_redacts_sensitive_fields() -> None:
+    """Diagnostics should redact sensitive keys and hide bulky schedules."""
+    hass = SimpleNamespace(
+        data={
+            "hoymiles_cloud": {
+                "entry-1": {
+                    "coordinator": FakeCoordinator(
+                        {
+                            "123": {
+                                "station_info": {"name": "Roof", "latitude": "1.23", "longitude": "4.56"},
+                                "devices": {"batteries": [{"sn": "BAT-1"}], "dtus": [], "inverters": [], "meters": []},
+                                "battery_settings": {"mode_data": {"k_8": {"time": [{"cs_time": "03:00"}]}}},
+                                "schedule_editor": {"modes": {"8": {"draft_payload": {"time": [{"cs_time": "03:00"}]}}}},
+                                "capabilities": {"has_battery": True},
+                            }
+                        }
+                    ),
+                    "api": FakeAPI(),
+                }
+            }
+        }
+    )
+    entry = SimpleNamespace(
+        entry_id="entry-1",
+        title="roof@example.com",
+        data={"auth_mode": "home_v3", "password": "secret"},
+        options={"scan_interval": 60},
+    )
+
+    diagnostics = asyncio.run(diagnostics_module.async_get_config_entry_diagnostics(hass, entry))
+
+    station = diagnostics["coordinator"]["stations"]["123"]
+    assert station["station_info"]["latitude"] == "**REDACTED**"
+    assert station["device_inventory"]["batteries"][0]["sn"] == "**REDACTED**"
+    assert station["battery_settings"]["mode_data"]["k_8"]["time"] == "<redacted>"
+    assert station["schedule_editor"]["modes"]["8"]["draft_payload"] == "<redacted>"

--- a/tests/test_hoymiles_api.py
+++ b/tests/test_hoymiles_api.py
@@ -171,8 +171,8 @@ def test_get_battery_settings_success_exposes_available_modes() -> None:
     assert api._session.requests[1]["kwargs"]["json"] == {"id": "job-123"}
 
 
-def test_set_battery_mode_polls_write_job_until_complete() -> None:
-    """Battery mode writes should follow the async write -> status polling flow."""
+def test_set_battery_mode_uses_direct_write_payload() -> None:
+    """Battery mode writes should use the direct station battery-config endpoint."""
     session = FakeSession(
         [
             {
@@ -196,17 +196,7 @@ def test_set_battery_mode_polls_write_job_until_complete() -> None:
             {
                 "status": "0",
                 "message": "success",
-                "data": "write-job",
-            },
-            {
-                "status": "0",
-                "message": "success",
-                "data": {"code": 2, "data": []},
-            },
-            {
-                "status": "0",
-                "message": "success",
-                "data": {"code": 0, "data": []},
+                "data": True,
             },
         ]
     )
@@ -218,11 +208,10 @@ def test_set_battery_mode_polls_write_job_until_complete() -> None:
 
     assert success is True
     assert session.requests[2]["kwargs"]["json"] == {
-        "action": 1013,
-        "data": {"sid": 123, "data": {"mode": 1, "data": {"reserve_soc": 10}}},
+        "sid": 123,
+        "mode": 1,
+        "data": {"reserve_soc": 10},
     }
-    assert session.requests[3]["kwargs"]["json"] == {"id": "write-job"}
-    assert session.requests[4]["kwargs"]["json"] == {"id": "write-job"}
 
 
 def test_set_battery_mode_settings_merges_into_existing_schedule_payload() -> None:
@@ -264,12 +253,7 @@ def test_set_battery_mode_settings_merges_into_existing_schedule_payload() -> No
             {
                 "status": "0",
                 "message": "success",
-                "data": "write-job",
-            },
-            {
-                "status": "0",
-                "message": "success",
-                "data": {"code": 0, "data": []},
+                "data": True,
             },
         ]
     )
@@ -283,27 +267,22 @@ def test_set_battery_mode_settings_merges_into_existing_schedule_payload() -> No
 
     assert success is True
     assert session.requests[2]["kwargs"]["json"] == {
-        "action": 1013,
+        "sid": 123,
+        "mode": 8,
         "data": {
-            "sid": 123,
-            "data": {
-                "mode": 8,
-                "data": {
-                    "reserve_soc": 15,
-                    "time": [
-                        {
-                            "cs_time": "03:00",
-                            "ce_time": "05:00",
-                            "c_power": 100,
-                            "dcs_time": "05:00",
-                            "dce_time": "03:00",
-                            "dc_power": 100,
-                            "charge_soc": 90,
-                            "dis_charge_soc": 10,
-                        }
-                    ],
-                },
-            },
+            "reserve_soc": 15,
+            "time": [
+                {
+                    "cs_time": "03:00",
+                    "ce_time": "05:00",
+                    "c_power": 100,
+                    "dcs_time": "05:00",
+                    "dce_time": "03:00",
+                    "dc_power": 100,
+                    "charge_soc": 90,
+                    "dis_charge_soc": 10,
+                }
+            ],
         },
     }
 
@@ -478,3 +457,119 @@ def test_auth_attempt_summary_lists_all_attempts() -> None:
     assert "home_v3[home/2.8.0]" in api.last_auth_attempt_summary
     assert "legacy_v0[web]" in api.last_auth_attempt_summary
     assert "sha256_v3" in api.last_auth_attempt_summary
+
+
+def test_get_station_details_uses_station_find_endpoint() -> None:
+    """Station detail reads should pass the station id as an integer."""
+    session = FakeSession(
+        [
+            {
+                "status": "0",
+                "message": "success",
+                "data": {"id": 123, "name": "Roof"},
+            }
+        ]
+    )
+    api = HoymilesAPI(session, "user@example.com", "secret")
+    api._token = "token"
+    api._token_expires_at = 9999999999
+
+    details = asyncio.run(api.get_station_details("123"))
+
+    assert details == {"id": 123, "name": "Roof"}
+    assert session.requests[0]["kwargs"]["json"] == {"id": 123}
+
+
+def test_get_relay_settings_success_exposes_payload() -> None:
+    """Successful relay reads should preserve the nested payload."""
+    session = FakeSession(
+        [
+            {
+                "status": "0",
+                "message": "success",
+                "data": "relay-job",
+            },
+            {
+                "status": "0",
+                "message": "success",
+                "data": {
+                    "code": 0,
+                    "data": {
+                        "mode": 0,
+                        "data": {
+                            "k_2": {"mode": 2},
+                            "k_3": {"mode": 0},
+                        },
+                    },
+                },
+            },
+        ]
+    )
+    api = HoymilesAPI(session, "user@example.com", "secret")
+    api._token = "token"
+    api._token_expires_at = 9999999999
+
+    relay_settings = asyncio.run(api.get_relay_settings("123"))
+
+    assert relay_settings["readable"] is True
+    assert relay_settings["writable"] is True
+    assert relay_settings["data"]["data"]["k_2"]["mode"] == 2
+    assert session.requests[0]["kwargs"]["json"] == {"action": 1014, "data": {"sid": 123}}
+    assert session.requests[1]["kwargs"]["json"] == {"id": "relay-job"}
+
+
+def test_set_relay_enabled_turns_on_default_nested_mode() -> None:
+    """Relay enable writes should seed a default k_2 mode when the payload is fully off."""
+    session = FakeSession(
+        [
+            {
+                "status": "0",
+                "message": "success",
+                "data": "relay-read",
+            },
+            {
+                "status": "0",
+                "message": "success",
+                "data": {
+                    "code": 0,
+                    "data": {
+                        "mode": 0,
+                        "data": {
+                            "k_2": {"mode": 0},
+                            "k_3": {"mode": 0},
+                        },
+                    },
+                },
+            },
+            {
+                "status": "0",
+                "message": "success",
+                "data": "relay-write",
+            },
+            {
+                "status": "0",
+                "message": "success",
+                "data": {"code": 0, "data": []},
+            },
+        ]
+    )
+    api = HoymilesAPI(session, "user@example.com", "secret")
+    api._token = "token"
+    api._token_expires_at = 9999999999
+
+    success = asyncio.run(api.set_relay_enabled("123", True))
+
+    assert success is True
+    assert session.requests[2]["kwargs"]["json"] == {
+        "action": 1014,
+        "data": {
+            "sid": 123,
+            "data": {
+                "mode": 1,
+                "data": {
+                    "k_2": {"mode": 2},
+                    "k_3": {"mode": 0},
+                },
+            },
+        },
+    }

--- a/tests/test_hoymiles_api.py
+++ b/tests/test_hoymiles_api.py
@@ -375,7 +375,11 @@ def test_decode_v3_salt_still_accepts_base64() -> None:
 
 
 def test_configured_auth_preferences_affect_future_attempts() -> None:
-    """Configured auth preferences should affect subsequent authenticate calls."""
+    """Configured auth preferences should affect subsequent authenticate calls.
+
+    The S-Miles Home profile has no built-in backend host, so an explicit
+    ``auth_base_url`` override is supplied to point it at a candidate host.
+    """
     session = FakeSession(
         [
             {"status": "0", "message": "success", "data": {"a": None, "n": "nonce1"}},
@@ -383,7 +387,11 @@ def test_configured_auth_preferences_affect_future_attempts() -> None:
         ]
     )
     api = HoymilesAPI(session, "user@example.com", "secret")
-    api.configure_auth(auth_mode="home_v3", app_version="2.8.0")
+    api.configure_auth(
+        auth_mode="home_v3",
+        app_version="2.8.0",
+        auth_base_url="https://home.example.com",
+    )
 
     authenticated = asyncio.run(api.authenticate())
 
@@ -391,6 +399,53 @@ def test_configured_auth_preferences_affect_future_attempts() -> None:
     assert api.auth_method == "home_v3:sha256_v3"
     assert api.last_auth_attempt == "home_v3"
     assert session.requests[0]["kwargs"]["headers"]["User-Agent"] == "S-Miles Home/2.8.0"
+    # The override host is honored for both pre-insp and login.
+    assert session.requests[0]["args"][0] == "https://home.example.com/iam/pub/3/auth/pre-insp"
+    assert session.requests[1]["args"][0] == "https://home.example.com/iam/pub/3/auth/login"
+
+
+def test_home_profile_fails_fast_without_backend_host() -> None:
+    """Explicitly selecting S-Miles Home with no backend host should fail fast."""
+    session = FakeSession([])
+    api = HoymilesAPI(session, "user@example.com", "secret")
+    api.configure_auth(auth_mode="home_v3")
+
+    authenticated = asyncio.run(api.authenticate())
+
+    assert authenticated is False
+    assert api.last_auth_error_key == AUTH_ERROR_S_MILES_HOME_REQUIRED
+    # No network request is made when the backend host is unknown.
+    assert session.requests == []
+
+
+def test_auto_detect_skips_home_profile_without_backend_host() -> None:
+    """Auto-detect should not attempt (or mislabel via) the home profile.
+
+    A wrong-password account must surface invalid_auth, not s_miles_home_required.
+    """
+    session = FakeSession(
+        [
+            # web_v3
+            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce1"}},
+            {"status": "1", "message": "Invalid credentials"},
+            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce2"}},
+            {"status": "1", "message": "Invalid credentials"},
+            # installer_v3
+            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce3"}},
+            {"status": "1", "message": "Invalid credentials"},
+            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce4"}},
+            {"status": "1", "message": "Invalid credentials"},
+            # legacy_v0
+            {"status": "1", "message": "Log in failed. Please check your account and password."},
+        ]
+    )
+    api = HoymilesAPI(session, "user@example.com", "secret")
+
+    authenticated = asyncio.run(api.authenticate())
+
+    assert authenticated is False
+    assert "home_v3" not in api.last_auth_attempt_summary
+    assert api.last_auth_error_key != AUTH_ERROR_S_MILES_HOME_REQUIRED
 
 
 def test_unsalted_v3_retries_with_sha256_hex_variant() -> None:
@@ -434,17 +489,22 @@ def test_pre_insp_accepts_top_level_payload_shape() -> None:
     assert api.auth_method == "web_v3:sha256_v3"
 
 
-def test_auth_attempt_summary_lists_all_attempts() -> None:
-    """Failed auth runs should keep a readable attempt summary."""
+def test_auth_attempt_summary_records_attempted_profiles() -> None:
+    """Failed auth runs should keep a readable summary of attempted profiles."""
     session = FakeSession(
         [
+            # web_v3
             {"status": "0", "message": "success", "data": {"a": None, "n": "nonce1"}},
             {"status": "1", "message": "Invalid credentials"},
             {"status": "0", "message": "success", "data": {"a": None, "n": "nonce2"}},
             {"status": "1", "message": "Your app version is low. Please update to the latest version."},
+            # installer_v3
             {"status": "0", "message": "success", "data": {"a": None, "n": "nonce3"}},
-            {"status": "1", "message": "Can only login to the S-Miles Home."},
             {"status": "1", "message": "Invalid credentials"},
+            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce4"}},
+            {"status": "1", "message": "Invalid credentials"},
+            # legacy_v0
+            {"status": "1", "message": "Log in failed. Please check your account and password."},
         ]
     )
     api = HoymilesAPI(session, "user@example.com", "secret")
@@ -454,9 +514,30 @@ def test_auth_attempt_summary_lists_all_attempts() -> None:
     assert authenticated is False
     assert "web_v3[web]" in api.last_auth_attempt_summary
     assert "installer_v3[installer/3.7.1]" in api.last_auth_attempt_summary
-    assert "home_v3[home/2.8.0]" in api.last_auth_attempt_summary
     assert "legacy_v0[web]" in api.last_auth_attempt_summary
-    assert "sha256_v3" in api.last_auth_attempt_summary
+    # The home profile has no backend host, so auto-detect skips it.
+    assert "home_v3[home/2.8.0]" not in api.last_auth_attempt_summary
+    assert "sha256_hex_v3" in api.last_auth_attempt_summary
+
+
+def test_auto_detect_short_circuits_on_s_miles_home_gate() -> None:
+    """Auto-detect should stop as soon as the S-Miles Home gate is returned."""
+    session = FakeSession(
+        [
+            # web_v3 returns the account-type gate on the first login attempt.
+            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce1"}},
+            {"status": "1", "message": "Can only login to the S-Miles Home."},
+        ]
+    )
+    api = HoymilesAPI(session, "user@example.com", "secret")
+
+    authenticated = asyncio.run(api.authenticate())
+
+    assert authenticated is False
+    assert api.last_auth_error_key == AUTH_ERROR_S_MILES_HOME_REQUIRED
+    # Only web_v3 was attempted; installer/legacy were not tried.
+    assert "installer_v3" not in api.last_auth_attempt_summary
+    assert "legacy_v0" not in api.last_auth_attempt_summary
 
 
 def test_get_station_details_uses_station_find_endpoint() -> None:


### PR DESCRIPTION
Brings the Hoymiles integration redesign to `main`, plus a dedicated fix/diagnosis for the **S-Miles Home login failures** reported in #30 and #27.

## S-Miles Home login (this commit)
Consumer **S-Miles Home** accounts (e.g. MS-A2 balcony storage) live on a different Hoymiles backend than `neapi.hoymiles.com`, so they hit a hard *"can only log in to the S-Miles Home app"* gate that no header/profile change can bypass.

- Per-profile auth backend host + `_auth_url()` helper; `home` profile has a `None` placeholder until its backend is known.
- Advanced `auth_base_url` override in `configure_auth` for testing a discovered host.
- `--auth-base-url` and sanitized `--dump-raw` in `scripts/test_login_flow.py`.
- Auto-detect skips profiles with no backend host (so a wrong password is not mislabeled as S-Miles Home) and short-circuits on the gate.
- Clearer `s_miles_home_required` error message; `home` selector relabeled "not yet supported".

All tests pass (`pytest tests/` → 32 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)