### PR TITLE
Fix S-Miles Home (MS-A2) login

### DIFF
--- a/custom_components/hoymiles_cloud/const.py
+++ b/custom_components/hoymiles_cloud/const.py
@@ -66,9 +66,23 @@ CLIENT_PROFILE_HOME = "home"
 
 DEFAULT_WEB_USER_AGENT = "HomeAssistant-HoymilesCloud"
 DEFAULT_INSTALLER_USER_AGENT = "S-Miles Installer"
-DEFAULT_HOME_USER_AGENT = "S-Miles Home"
 DEFAULT_INSTALLER_APP_VERSION = "3.7.1"
-DEFAULT_HOME_APP_VERSION = "2.8.0"
+
+# S-Miles Home (consumer / MS-A2 balcony) app identity.
+#
+# These accounts are gated server-side: every endpoint returns "The account can
+# only be used for logging in to the S-Miles Home app" UNLESS the request sends
+# the genuine consumer-app User-Agent. The S-Miles Home Android app builds it as
+# "sma/ad/{app_version}/{tid}/{dc}" (see HttpUtils.n() in com.hm.balcony). The
+# tid identifies the brand/tag (159 = HOYMILES) and matches the "t" field the
+# server returns in the pre-insp response; dc is a data-center hint that starts
+# at 0 (the server returns the real value). Sending this User-Agent against the
+# normal neapi host (it 307-redirects auth to the regional gateway) is enough to
+# pass the gate; data endpoints then work on the standard host. See issue #30.
+DEFAULT_HOME_USER_AGENT_PREFIX = "sma/ad"
+DEFAULT_HOME_APP_VERSION = "2.10.0"
+HOME_CLIENT_TID = 159
+HOME_CLIENT_DC = 0
 
 AUTH_PROFILE_DEFAULTS = {
     CLIENT_PROFILE_WEB: {
@@ -84,16 +98,20 @@ AUTH_PROFILE_DEFAULTS = {
         "base_url": API_BASE_URL,
     },
     CLIENT_PROFILE_HOME: {
-        "user_agent": DEFAULT_HOME_USER_AGENT,
+        # Consumer S-Miles Home app identity (see note above). The User-Agent is
+        # built in a special "sma/ad/{version}/{tid}/{dc}" format rather than the
+        # "{user_agent}/{version}" form used by the other profiles.
+        "user_agent": DEFAULT_HOME_USER_AGENT_PREFIX,
         "app_version": DEFAULT_HOME_APP_VERSION,
-        "x_client_type": "mobile",
-        # TODO: S-Miles Home consumer backend. Consumer "S-Miles Home" /
-        # "S-Miles Enduser" accounts (e.g. MS-A2 balcony storage) live on a
-        # different Hoymiles backend than neapi.hoymiles.com. Once a sanitized
-        # network trace of the S-Miles Home mobile app login is available, set
-        # this to the real host (and adjust headers/request body as needed).
-        # See GitHub issue #30.
-        "base_url": None,
+        "x_client_type": None,
+        "ua_style": "smiles_app",
+        "tid": HOME_CLIENT_TID,
+        "dc": HOME_CLIENT_DC,
+        # Auth must target the EU consumer gateway directly. The default neapi
+        # host 307-redirects auth requests, which invalidates the pre-insp
+        # nonce and makes login fail. Data endpoints still work on the standard
+        # neapi host with the issued token, so only auth is pinned here.
+        "base_url": API_EU_BASE_URL,
     },
 }
 
@@ -107,7 +125,7 @@ AUTH_MODE_OPTIONS = {
     AUTH_MODE_AUTO: "Auto-detect",
     AUTH_MODE_WEB_V3: "S-Miles Cloud Web",
     AUTH_MODE_INSTALLER_V3: "S-Miles Installer",
-    AUTH_MODE_HOME_V3: "S-Miles Home (not yet supported)",
+    AUTH_MODE_HOME_V3: "S-Miles Home (MS-A2 / balcony)",
     AUTH_MODE_LEGACY_V0: "Legacy v0",
 }
 

--- a/custom_components/hoymiles_cloud/hoymiles_api.py
+++ b/custom_components/hoymiles_cloud/hoymiles_api.py
@@ -13,7 +13,6 @@ from typing import Any, Dict, Optional
 import aiohttp
 
 from .auth import (
-    AUTH_ERROR_S_MILES_HOME_REQUIRED,
     AuthAttempt,
     choose_preferred_failure,
     summarize_auth_attempts,
@@ -58,6 +57,9 @@ from .const import (
     AUTH_MODE_WEB_V3,
     AUTH_MODE_TO_PROFILE,
     AUTH_PROFILE_DEFAULTS,
+    DEFAULT_HOME_APP_VERSION,
+    HOME_CLIENT_DC,
+    HOME_CLIENT_TID,
     CLIENT_PROFILE_HOME,
     CLIENT_PROFILE_INSTALLER,
     CLIENT_PROFILE_WEB,
@@ -241,6 +243,18 @@ class HoymilesAPI:
         profile_defaults = AUTH_PROFILE_DEFAULTS[client_profile]
         version = self._resolve_app_version(client_profile, app_version=app_version)
         user_agent = profile_defaults["user_agent"]
+
+        # The S-Miles Home (consumer / MS-A2) profile must present the genuine
+        # mobile-app User-Agent "sma/ad/{version}/{tid}/{dc}" — anything else is
+        # rejected with "account can only be used for logging in to the S-Miles
+        # Home app". This is the sole differentiator that passes the gate.
+        if profile_defaults.get("ua_style") == "smiles_app":
+            effective_version = version or DEFAULT_HOME_APP_VERSION
+            tid = profile_defaults.get("tid", HOME_CLIENT_TID)
+            dc = profile_defaults.get("dc", HOME_CLIENT_DC)
+            headers["User-Agent"] = f"{user_agent}/{effective_version}/{tid}/{dc}"
+            return headers
+
         if version:
             headers["User-Agent"] = f"{user_agent}/{version}"
             headers["App-Version"] = version
@@ -780,12 +794,6 @@ class HoymilesAPI:
                 else:
                     attempt = await self._authenticate_v3(client_profile=client_profile)
                 attempts.append(attempt)
-
-                # Once the server reports the account is restricted to the
-                # S-Miles Home app, the remaining profiles hit the same host
-                # and fail identically. Stop early to avoid pointless retries.
-                if not attempt.success and attempt.error_key == AUTH_ERROR_S_MILES_HOME_REQUIRED:
-                    break
 
             self._last_auth_attempts = attempts
             for attempt in attempts:

--- a/custom_components/hoymiles_cloud/translations/en.json
+++ b/custom_components/hoymiles_cloud/translations/en.json
@@ -28,7 +28,7 @@
       "cannot_connect": "Failed to connect to Hoymiles Cloud",
       "invalid_auth": "Invalid authentication",
       "app_update_required": "Hoymiles rejected the login because the client version is too old",
-      "s_miles_home_required": "This is a consumer S-Miles Home account (typical for MS-A2 balcony storage). It uses a different Hoymiles backend that this integration does not support yet, so changing the authentication mode will not help. See https://github.com/Philra94/homeassistant-hoymiles-cloud/issues/30 if you can help capture the app's login details.",
+      "s_miles_home_required": "This S-Miles Home account could not be authenticated. Make sure you are on the latest version and try the 'S-Miles Home' authentication mode. If it still fails, please report it at https://github.com/Philra94/homeassistant-hoymiles-cloud/issues/30.",
       "no_stations": "No stations found for this account",
       "no_accessible_stations": "Authentication succeeded, but no accessible stations were returned for this account",
       "unknown": "Unexpected error"
@@ -39,7 +39,7 @@
           "auto": "Auto-detect",
           "web_v3": "S-Miles Cloud Web",
           "installer_v3": "S-Miles Installer",
-          "home_v3": "S-Miles Home (not yet supported)",
+          "home_v3": "S-Miles Home (MS-A2 / balcony)",
           "legacy_v0": "Legacy v0"
         }
       }

--- a/tests/test_hoymiles_api.py
+++ b/tests/test_hoymiles_api.py
@@ -344,16 +344,21 @@ def test_installer_profile_headers_include_version_metadata() -> None:
     assert headers["X-Client-Type"] == "mobile"
 
 
-def test_home_profile_headers_include_version_metadata() -> None:
-    """Home-profile requests should include explicit version headers."""
+def test_home_profile_uses_smiles_app_user_agent() -> None:
+    """The S-Miles Home profile must present the genuine consumer-app User-Agent.
+
+    The server gates these accounts unless the request sends
+    ``sma/ad/{version}/{tid}/{dc}`` (tid 159 = HOYMILES). It must NOT send the
+    installer-style App-Version / X-Client-Type headers.
+    """
     api = HoymilesAPI(FakeSession([]), "user@example.com", "secret")
 
-    headers = api._json_headers(client_profile="home", app_version="2.8.0")
+    headers = api._json_headers(client_profile="home", app_version="2.10.0")
 
-    assert headers["User-Agent"] == "S-Miles Home/2.8.0"
-    assert headers["App-Version"] == "2.8.0"
-    assert headers["X-App-Version"] == "2.8.0"
-    assert headers["X-Client-Type"] == "mobile"
+    assert headers["User-Agent"] == "sma/ad/2.10.0/159/0"
+    assert "App-Version" not in headers
+    assert "X-App-Version" not in headers
+    assert "X-Client-Type" not in headers
 
 
 def test_decode_v3_salt_prefers_hex_browser_format() -> None:
@@ -377,8 +382,8 @@ def test_decode_v3_salt_still_accepts_base64() -> None:
 def test_configured_auth_preferences_affect_future_attempts() -> None:
     """Configured auth preferences should affect subsequent authenticate calls.
 
-    The S-Miles Home profile has no built-in backend host, so an explicit
-    ``auth_base_url`` override is supplied to point it at a candidate host.
+    The S-Miles Home profile sends the consumer-app User-Agent; an explicit
+    ``auth_base_url`` override is honored for the request host.
     """
     session = FakeSession(
         [
@@ -389,7 +394,7 @@ def test_configured_auth_preferences_affect_future_attempts() -> None:
     api = HoymilesAPI(session, "user@example.com", "secret")
     api.configure_auth(
         auth_mode="home_v3",
-        app_version="2.8.0",
+        app_version="2.10.0",
         auth_base_url="https://home.example.com",
     )
 
@@ -398,54 +403,39 @@ def test_configured_auth_preferences_affect_future_attempts() -> None:
     assert authenticated is True
     assert api.auth_method == "home_v3:sha256_v3"
     assert api.last_auth_attempt == "home_v3"
-    assert session.requests[0]["kwargs"]["headers"]["User-Agent"] == "S-Miles Home/2.8.0"
+    assert session.requests[0]["kwargs"]["headers"]["User-Agent"] == "sma/ad/2.10.0/159/0"
     # The override host is honored for both pre-insp and login.
     assert session.requests[0]["args"][0] == "https://home.example.com/iam/pub/3/auth/pre-insp"
     assert session.requests[1]["args"][0] == "https://home.example.com/iam/pub/3/auth/login"
 
 
-def test_home_profile_fails_fast_without_backend_host() -> None:
-    """Explicitly selecting S-Miles Home with no backend host should fail fast."""
-    session = FakeSession([])
-    api = HoymilesAPI(session, "user@example.com", "secret")
-    api.configure_auth(auth_mode="home_v3")
+def test_auto_detect_falls_through_to_home_profile_when_gated() -> None:
+    """When web/installer hit the S-Miles Home gate, auto-detect tries home.
 
-    authenticated = asyncio.run(api.authenticate())
-
-    assert authenticated is False
-    assert api.last_auth_error_key == AUTH_ERROR_S_MILES_HOME_REQUIRED
-    # No network request is made when the backend host is unknown.
-    assert session.requests == []
-
-
-def test_auto_detect_skips_home_profile_without_backend_host() -> None:
-    """Auto-detect should not attempt (or mislabel via) the home profile.
-
-    A wrong-password account must surface invalid_auth, not s_miles_home_required.
+    The home profile sends the consumer-app User-Agent, which passes the gate,
+    so auto-detect succeeds via home_v3 instead of failing.
     """
     session = FakeSession(
         [
-            # web_v3
-            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce1"}},
-            {"status": "1", "message": "Invalid credentials"},
-            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce2"}},
-            {"status": "1", "message": "Invalid credentials"},
-            # installer_v3
-            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce3"}},
-            {"status": "1", "message": "Invalid credentials"},
-            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce4"}},
-            {"status": "1", "message": "Invalid credentials"},
-            # legacy_v0
-            {"status": "1", "message": "Log in failed. Please check your account and password."},
+            # web_v3 pre-insp -> account-type gate
+            {"status": "1", "message": "The account can only be used for logging in to the S-Miles Home app."},
+            # installer_v3 pre-insp -> account-type gate
+            {"status": "1", "message": "The account can only be used for logging in to the S-Miles Home app."},
+            # home_v3 pre-insp + login succeed (consumer-app User-Agent passes the gate)
+            {"status": "0", "message": "success", "data": {"a": None, "n": "nonceH"}},
+            {"status": "0", "message": "success", "data": {"token": "token-home"}},
         ]
     )
     api = HoymilesAPI(session, "user@example.com", "secret")
 
     authenticated = asyncio.run(api.authenticate())
 
-    assert authenticated is False
-    assert "home_v3" not in api.last_auth_attempt_summary
-    assert api.last_auth_error_key != AUTH_ERROR_S_MILES_HOME_REQUIRED
+    assert authenticated is True
+    assert api.last_auth_attempt == "home_v3"
+    assert api.auth_method == "home_v3:sha256_v3"
+    # The home pre-insp/login used the consumer-app User-Agent.
+    home_ua = session.requests[-1]["kwargs"]["headers"]["User-Agent"]
+    assert home_ua.startswith("sma/ad/") and home_ua.endswith("/159/0")
 
 
 def test_unsalted_v3_retries_with_sha256_hex_variant() -> None:
@@ -493,17 +483,13 @@ def test_auth_attempt_summary_records_attempted_profiles() -> None:
     """Failed auth runs should keep a readable summary of attempted profiles."""
     session = FakeSession(
         [
-            # web_v3
-            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce1"}},
-            {"status": "1", "message": "Invalid credentials"},
-            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce2"}},
-            {"status": "1", "message": "Your app version is low. Please update to the latest version."},
-            # installer_v3
-            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce3"}},
-            {"status": "1", "message": "Invalid credentials"},
-            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce4"}},
-            {"status": "1", "message": "Invalid credentials"},
-            # legacy_v0
+            # web_v3 pre-insp -> gate
+            {"status": "1", "message": "The account can only be used for logging in to the S-Miles Home app."},
+            # installer_v3 pre-insp -> gate
+            {"status": "1", "message": "The account can only be used for logging in to the S-Miles Home app."},
+            # home_v3 pre-insp -> gate
+            {"status": "1", "message": "The account can only be used for logging in to the S-Miles Home app."},
+            # legacy_v0 login -> failure
             {"status": "1", "message": "Log in failed. Please check your account and password."},
         ]
     )
@@ -512,32 +498,12 @@ def test_auth_attempt_summary_records_attempted_profiles() -> None:
     authenticated = asyncio.run(api.authenticate())
 
     assert authenticated is False
+    # All four profiles are attempted and recorded (auto-detect no longer
+    # short-circuits, so the home profile is always tried).
     assert "web_v3[web]" in api.last_auth_attempt_summary
     assert "installer_v3[installer/3.7.1]" in api.last_auth_attempt_summary
+    assert "home_v3[home/2.10.0]" in api.last_auth_attempt_summary
     assert "legacy_v0[web]" in api.last_auth_attempt_summary
-    # The home profile has no backend host, so auto-detect skips it.
-    assert "home_v3[home/2.8.0]" not in api.last_auth_attempt_summary
-    assert "sha256_hex_v3" in api.last_auth_attempt_summary
-
-
-def test_auto_detect_short_circuits_on_s_miles_home_gate() -> None:
-    """Auto-detect should stop as soon as the S-Miles Home gate is returned."""
-    session = FakeSession(
-        [
-            # web_v3 returns the account-type gate on the first login attempt.
-            {"status": "0", "message": "success", "data": {"a": None, "n": "nonce1"}},
-            {"status": "1", "message": "Can only login to the S-Miles Home."},
-        ]
-    )
-    api = HoymilesAPI(session, "user@example.com", "secret")
-
-    authenticated = asyncio.run(api.authenticate())
-
-    assert authenticated is False
-    assert api.last_auth_error_key == AUTH_ERROR_S_MILES_HOME_REQUIRED
-    # Only web_v3 was attempted; installer/legacy were not tried.
-    assert "installer_v3" not in api.last_auth_attempt_summary
-    assert "legacy_v0" not in api.last_auth_attempt_summary
 
 
 def test_get_station_details_uses_station_find_endpoint() -> None:


### PR DESCRIPTION
Fixes the long-standing **"account can only be used for logging in to the S-Miles Home app"** login failure (#30, #27).

## Root cause
The gate is triggered solely by the `User-Agent`. The genuine S-Miles Home app (`com.hm.balcony`) sends `sma/ad/{version}/{tid}/{dc}` (e.g. `sma/ad/2.10.0/159/0`; tid 159 = HOYMILES, the `t` field in pre-insp responses). The integration sent `S-Miles Home/2.8.0`, which the server rejects.

## Fix
- `home` profile sends the `sma/ad` consumer-app User-Agent.
- `home` auth targets `euapi.hoymiles.com` directly (default `neapi` 307-redirects auth and invalidates the nonce); data endpoints keep working on the standard host with the token.
- auto-detect falls through to `home_v3` (removed the obsolete short-circuit).
- selector label + error copy updated; tests updated (30 passed).

Verified end-to-end against a real S-Miles Home account (auth OK; data API works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)