### PR TITLE
fix(battery): follow-up to #49 — move flow-direction logic to data.py, fix idle state and battery_charging sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This custom integration for Home Assistant allows you to monitor and control you
 
 - **Data Monitoring:**
   - Solar PV power generation
-  - Battery power (charge/discharge)
+  - Battery power (signed: positive = discharging, negative = charging)
   - Battery state of charge
   - Grid power import/export
   - Load power consumption
@@ -21,6 +21,25 @@ This custom integration for Home Assistant allows you to monitor and control you
   - Peak Shaving Mode specific settings (`max_soc`, `meter_power`) when supported
   - Home Assistant-native draft editors for Economy and Time of Use schedules using built-in selects, text fields, numbers, buttons, and summary sensors
   - Advanced battery mode payload updates through Home Assistant services for Economy and Time of Use schedules
+
+## Breaking change in 1.2.0: battery power sign convention
+
+The Hoymiles API always reports `bms_power` as a positive magnitude, so the
+`battery_power` sensor previously read positive while charging *and* while
+discharging, and the `battery_charging` binary sensor was stuck on. Since
+version 1.2.0 the sign and the flow direction are taken from the `flows` array
+of the live indicators payload:
+
+- **positive `battery_power` = discharging** (battery feeds the house/grid)
+- **negative `battery_power` = charging** (battery is the flow target)
+- `battery_flow_direction` and `battery_charging` follow the same source and
+  report `unknown` while the battery is idle (no battery entry in `flows`)
+
+**Upgrading:** existing installs will see `battery_power` flip sign while
+charging. Dashboards, templates, automations and long-term statistics that were
+written against the old always-positive value need to be reviewed, and existing
+statistics for that entity mix both conventions. Accounts whose firmware does
+not return a `flows` array keep the previous behaviour.
 
 ## Development Status
 

--- a/custom_components/hoymiles_cloud/binary_sensor.py
+++ b/custom_components/hoymiles_cloud/binary_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
 from .const import DOMAIN
+from .data import is_battery_charging
 from .device import build_primary_battery_device_info, build_station_device_info
 
 
@@ -30,21 +31,11 @@ def get_reflux_data(station_data: dict[str, Any]) -> dict[str, Any]:
     return station_data.get("real_time_data", {}).get("reflux_station_data", {})
 
 
-def safe_float(value: Any) -> float | None:
-    """Return a float if the value is numeric."""
-    try:
-        if value in (None, "", "-"):
-            return None
-        return float(value)
-    except (TypeError, ValueError):
-        return None
-
-
 @dataclass
 class HoymilesBinarySensorDescription(BinarySensorEntityDescription):
     """Declarative binary sensor definition."""
 
-    value_fn: Callable[[dict[str, Any]], bool] | None = None
+    value_fn: Callable[[dict[str, Any]], bool | None] | None = None
     exists_fn: Callable[[dict[str, Any]], bool] | None = None
     device_info_fn: Callable[[str, str, dict[str, Any]], dict[str, Any]] | None = None
 
@@ -54,7 +45,7 @@ DESCRIPTIONS: list[HoymilesBinarySensorDescription] = [
         key="battery_charging",
         name="Battery Charging",
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
-        value_fn=lambda data: (safe_float(get_reflux_data(data).get("bms_power")) or 0.0) > 0,
+        value_fn=is_battery_charging,
         exists_fn=lambda data: bool(data.get("capabilities", {}).get("battery_telemetry")),
         device_info_fn=lambda sid, name, data: build_primary_battery_device_info(sid, name, data),
     ),
@@ -141,10 +132,13 @@ class HoymilesBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool | None:
-        """Return whether the binary sensor is on."""
+        """Return whether the binary sensor is on, or None when unknown."""
         if not self.entity_description.value_fn:
             return None
-        return bool(self.entity_description.value_fn(self._get_station_data()))
+        value = self.entity_description.value_fn(self._get_station_data())
+        if value is None:
+            return None
+        return bool(value)
 
     @property
     def available(self) -> bool:

--- a/custom_components/hoymiles_cloud/const.py
+++ b/custom_components/hoymiles_cloud/const.py
@@ -202,7 +202,10 @@ INDICATOR_TYPE_GRID = 2
 INDICATOR_TYPE_PV = 4
 INDICATOR_TYPE_METER_ES = 5
 
-# Indicator flow types
+# Node types used in the ``flows`` array of the indicators payload. Every flow
+# entry links a source (``out``) to a target (``in``) node. Only the battery
+# node is evaluated by the integration today; the remaining members are kept to
+# document the API's node-type enum for future flow-based sensors.
 INDICATOR_FLOW_STAT_TYPE_LOAD = 1
 INDICATOR_FLOW_STAT_TYPE_GRID = 2
 INDICATOR_FLOW_STAT_TYPE_PV = 4

--- a/custom_components/hoymiles_cloud/data.py
+++ b/custom_components/hoymiles_cloud/data.py
@@ -13,6 +13,7 @@ from .const import (
     BATTERY_MODE_SELF_CONSUMPTION_MAX_POWER,
     BATTERY_MODE_TIME_OF_USE,
     BATTERY_SCHEDULE_MODE_IDS,
+    INDICATOR_FLOW_STAT_TYPE_BATTERY,
     METER_LOCATION_NAMES,
     MODULE_DATA_MAX_AGE_MINUTES,
     MODULE_DATA_PRECISION,
@@ -29,6 +30,10 @@ MODE_KEY_MAPPING = {
     7: "k_7",
     8: "k_8",
 }
+
+# Sign applied to the battery power magnitude reported by the API.
+BATTERY_FLOW_DISCHARGING = 1
+BATTERY_FLOW_CHARGING = -1
 
 ECONOMY_DURATION_TYPES = (1, 2, 3)
 DEFAULT_WEEK_GROUPS = (
@@ -875,6 +880,91 @@ def get_energy_flow_value(energy_flow: dict[str, Any] | None, key: str) -> float
     if not energy_flow:
         return None
     return energy_flow.get(key)
+
+
+def _reflux_data(station_data: dict[str, Any] | None) -> dict[str, Any]:
+    """Return the live reflux payload of a station."""
+    return (station_data or {}).get("real_time_data", {}).get("reflux_station_data", {})
+
+
+def _optional_float(value: Any) -> float | None:
+    """Coerce a value to float, returning None for missing/placeholder values."""
+    if value is None or value in ("", "-"):
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def get_battery_flows(station_data: dict[str, Any] | None) -> list[Any] | None:
+    """Return the live ``flows`` array, or None when the payload has none.
+
+    A missing or malformed array means the account/firmware does not report
+    flows at all, which callers use to decide whether a legacy fallback is
+    allowed.
+    """
+    flows = _reflux_data(station_data).get("flows")
+    if not isinstance(flows, list):
+        return None
+    return flows
+
+
+def get_battery_flow_direction(station_data: dict[str, Any] | None) -> int | None:
+    """Return 1 for discharging, -1 for charging, None if unknown.
+
+    Each entry of the API ``flows`` array links a source (``out``) to a target
+    (``in``) node. ``out: 10`` means the battery is the source (discharging);
+    ``in: 10`` means it is the target (charging). An idle battery has no flow
+    entry at all, which yields None.
+    """
+    flows = get_battery_flows(station_data)
+    if flows is None:
+        return None
+    for flow in flows:
+        if not isinstance(flow, dict):
+            continue
+        if flow.get("out") == INDICATOR_FLOW_STAT_TYPE_BATTERY:
+            return BATTERY_FLOW_DISCHARGING
+        if flow.get("in") == INDICATOR_FLOW_STAT_TYPE_BATTERY:
+            return BATTERY_FLOW_CHARGING
+    return None
+
+
+def get_signed_battery_power(station_data: dict[str, Any] | None) -> float | None:
+    """Return signed battery power: positive = discharging, negative = charging.
+
+    The API always reports ``bms_power`` as a positive magnitude, so the sign is
+    taken from the live flow direction. Without a battery flow entry the battery
+    is idle (magnitude ~0) or the account does not report flows at all; in both
+    cases the unsigned magnitude is returned.
+    """
+    raw = _optional_float(_reflux_data(station_data).get("bms_power"))
+    if raw is None:
+        return None
+    direction = get_battery_flow_direction(station_data)
+    if direction is None:
+        return raw
+    return round(raw * direction, 2)
+
+
+def is_battery_charging(station_data: dict[str, Any] | None) -> bool | None:
+    """Return whether the battery is charging, or None when unknown."""
+    direction = get_battery_flow_direction(station_data)
+    if direction is not None:
+        return direction == BATTERY_FLOW_CHARGING
+    if get_battery_flows(station_data) is not None:
+        # Flow data is present but lists no battery node: the battery is idle,
+        # so there is no direction to report. Falling back to the sign of
+        # ``bms_power`` here would always claim "charging".
+        return None
+    # No flow data at all (older/different firmware): keep the legacy fallback.
+    bms_power = _optional_float(_reflux_data(station_data).get("bms_power"))
+    if bms_power is not None:
+        return bms_power > 0
+    return None
 
 
 def has_battery_telemetry(real_time_data: dict[str, Any] | None) -> bool:

--- a/custom_components/hoymiles_cloud/manifest.json
+++ b/custom_components/hoymiles_cloud/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "single_config_entry": false,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "requirements": [
     "aiohttp>=3.8.0",
     "argon2-cffi>=21.3.0"

--- a/custom_components/hoymiles_cloud/sensor.py
+++ b/custom_components/hoymiles_cloud/sensor.py
@@ -30,7 +30,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from .const import BATTERY_MODES, DOMAIN, METER_LOCATION_NAMES, INDICATOR_FLOW_STAT_TYPE_BATTERY
+from .const import BATTERY_MODES, DOMAIN, METER_LOCATION_NAMES
 from .data import (
     battery_settings_readable,
     discover_pv_channels,
@@ -38,9 +38,11 @@ from .data import (
     get_energy_flow_value,
     get_indicator_value,
     get_mode_settings,
-    get_schedule_modes,
-    get_supported_modes,
     get_pv_indicator_value,
+    get_schedule_modes,
+    get_signed_battery_power,
+    get_supported_modes,
+    is_battery_charging,
 )
 from .device import (
     build_battery_device_info,
@@ -113,48 +115,6 @@ def get_reflux_data(station_data: dict[str, Any]) -> dict[str, Any]:
 def get_nested_energy_total(station_data: dict[str, Any], key: str, period: str) -> int | None:
     """Return one nested energy total from the reflux data."""
     return safe_int_convert(get_reflux_data(station_data).get(key, {}).get(period))
-
-
-def _get_battery_flow_direction(station_data: dict[str, Any]) -> int | None:
-    """Return -1 for charging, 1 for discharging, None if unknown.
-
-    The API ``flows`` array contains entries where one field equals ``10``
-    (the battery node).  ``out: 10`` means the battery is the source
-    (discharging); ``in: 10`` means it is the target (charging).
-    """
-    flows = get_reflux_data(station_data).get("flows")
-    if not isinstance(flows, list):
-        return None
-    for flow in flows:
-        if not isinstance(flow, dict):
-            continue
-        if flow.get("out") == INDICATOR_FLOW_STAT_TYPE_BATTERY:
-            return 1
-        if flow.get("in") == INDICATOR_FLOW_STAT_TYPE_BATTERY:
-            return -1
-    return None
-
-
-def get_signed_battery_power(station_data: dict[str, Any]) -> float | None:
-    """Return signed battery power: positive = discharging, negative = charging."""
-    raw = safe_float_convert(get_reflux_data(station_data).get("bms_power"))
-    if raw is None:
-        return None
-    direction = _get_battery_flow_direction(station_data)
-    if direction is None:
-        return raw  # fallback: no flow info, return unsigned magnitude
-    return round(raw * direction, 2)
-
-
-def is_battery_charging(station_data: dict[str, Any]) -> bool | None:
-    """Determine whether the battery is charging based on live flows."""
-    direction = _get_battery_flow_direction(station_data)
-    if direction is not None:
-        return direction != 1
-    bms_power = safe_float_convert(get_reflux_data(station_data).get("bms_power"))
-    if bms_power is not None:
-        return bms_power > 0
-    return None
 
 
 def has_pv_indicator(station_data: dict[str, Any], key: str) -> bool:
@@ -268,7 +228,7 @@ STATION_SENSORS: list[HoymilesSensorDescription] = [
         suggested_display_precision=2,
         exists_fn=has_battery_telemetry,
         device_info_fn=get_battery_device_info,
-        value_fn=lambda data: get_signed_battery_power(data),
+        value_fn=get_signed_battery_power,
     ),
     HoymilesSensorDescription(
         key="battery_flow_direction",

--- a/custom_components/hoymiles_cloud/translations/en.json
+++ b/custom_components/hoymiles_cloud/translations/en.json
@@ -67,14 +67,15 @@
       "battery_power": {
         "name": "Battery Power",
         "state_attributes": {
-          "direction": "Power flow direction (positive = charging, negative = discharging)"
+          "direction": "Power flow direction (positive = discharging, negative = charging)"
         }
       },
       "battery_flow_direction": {
         "name": "Battery Flow Direction",
         "state": {
           "charging": "Charging",
-          "discharging": "Discharging"
+          "discharging": "Discharging",
+          "unknown": "Unknown"
         }
       },
       "battery_soc": {

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -14,7 +14,10 @@ build_station_capabilities = data_module.build_station_capabilities
 discover_pv_channels = data_module.discover_pv_channels
 find_placeholder_pv_channels = data_module.find_placeholder_pv_channels
 get_allowed_battery_modes = data_module.get_allowed_battery_modes
+get_battery_flow_direction = data_module.get_battery_flow_direction
 get_schedule_modes = data_module.get_schedule_modes
+get_signed_battery_power = data_module.get_signed_battery_power
+is_battery_charging = data_module.is_battery_charging
 latest_module_values = data_module.latest_module_values
 merge_missing_pv_channel_values = data_module.merge_missing_pv_channel_values
 relay_settings_enabled = data_module.relay_settings_enabled
@@ -462,3 +465,83 @@ def test_latest_module_values_handles_missing_chart() -> None:
         "MODULE_V": None,
         "MODULE_I": None,
     }
+
+
+def _station(reflux: dict | None) -> dict:
+    """Build a minimal station payload carrying the reflux data."""
+    return {"real_time_data": {"reflux_station_data": reflux if reflux is not None else {}}}
+
+
+def test_battery_flow_direction_charging() -> None:
+    """``in: 10`` marks the battery as the flow target, i.e. charging."""
+    station = _station({"bms_power": "812.0", "flows": [{"out": 4, "in": 10}]})
+
+    assert get_battery_flow_direction(station) == -1
+    assert is_battery_charging(station) is True
+    assert get_signed_battery_power(station) == -812.0
+
+
+def test_battery_flow_direction_discharging() -> None:
+    """``out: 10`` marks the battery as the flow source, i.e. discharging."""
+    station = _station({"bms_power": "450.5", "flows": [{"out": 10, "in": 1}]})
+
+    assert get_battery_flow_direction(station) == 1
+    assert is_battery_charging(station) is False
+    assert get_signed_battery_power(station) == 450.5
+
+
+def test_battery_flow_without_battery_node_is_unknown() -> None:
+    """An idle battery has no flow entry, so the direction stays unknown."""
+    station = _station({"bms_power": "0", "flows": [{"out": 4, "in": 1}, {"out": 2, "in": 1}]})
+
+    assert get_battery_flow_direction(station) is None
+    # The legacy ``bms_power > 0`` fallback must not claim "charging" here.
+    assert is_battery_charging(station) is None
+    assert get_signed_battery_power(station) == 0.0
+
+
+def test_battery_flow_empty_list_is_unknown() -> None:
+    """An empty flow array is still flow data, so no fallback is applied."""
+    station = _station({"bms_power": "120", "flows": []})
+
+    assert is_battery_charging(station) is None
+
+
+def test_battery_charging_falls_back_without_flow_data() -> None:
+    """Accounts that never report flows keep the legacy magnitude fallback."""
+    station = _station({"bms_power": "120"})
+
+    assert get_battery_flow_direction(station) is None
+    assert is_battery_charging(station) is True
+    assert get_signed_battery_power(station) == 120.0
+
+
+def test_battery_charging_falls_back_to_discharging_without_flow_data() -> None:
+    """A non-positive magnitude without flow data reports discharging."""
+    station = _station({"bms_power": "-30"})
+
+    assert is_battery_charging(station) is False
+    assert get_signed_battery_power(station) == -30.0
+
+
+def test_battery_helpers_handle_missing_bms_power() -> None:
+    """Missing or placeholder power yields unknown values, not zero."""
+    assert get_signed_battery_power(_station({})) is None
+    assert is_battery_charging(_station({})) is None
+    assert get_signed_battery_power(_station({"bms_power": "-"})) is None
+    assert is_battery_charging(_station({"bms_power": ""})) is None
+    assert get_signed_battery_power({}) is None
+    assert get_signed_battery_power(None) is None
+
+
+def test_battery_flow_direction_handles_malformed_flows() -> None:
+    """Non-list or non-dict flow payloads never raise."""
+    non_list = _station({"bms_power": "75", "flows": {"out": 10}})
+    assert get_battery_flow_direction(non_list) is None
+    # A malformed ``flows`` value counts as "no flow data", so the fallback applies.
+    assert is_battery_charging(non_list) is True
+    assert get_signed_battery_power(non_list) == 75.0
+
+    junk_entries = _station({"bms_power": "75", "flows": ["nonsense", None, {"out": 10, "in": 1}]})
+    assert get_battery_flow_direction(junk_entries) == 1
+    assert get_signed_battery_power(junk_entries) == 75.0


### PR DESCRIPTION
Follow-up to #49, which fixed the battery power sign and flow direction by reading the API `flows` array (`out: 10` = battery is the source → discharging, `in: 10` = battery is the target → charging) instead of the sign of `bms_power`, which the API always returns as a positive magnitude.

That PR left three loose ends, addressed here.

## Changes

### 1. Helpers moved to `data.py`
`_get_battery_flow_direction`, `get_signed_battery_power` and `is_battery_charging` lived in `sensor.py`, which imports Home Assistant unconditionally and therefore cannot be loaded by the standalone test loader (see the Architecture section of `AGENTS.md`). They now live in `data.py` next to `get_reflux_data`/`has_battery_telemetry`, and `sensor.py` imports them. Public behaviour is unchanged; `_get_battery_flow_direction` became the public `get_battery_flow_direction`, plus a small `get_battery_flows` helper used to tell "no flow data" apart from "flow data without a battery node".

### 2. `battery_charging` binary sensor fixed
`binary_sensor.py` still used `(safe_float(get_reflux_data(data).get("bms_power")) or 0.0) > 0`, so the entity reported "charging" permanently. It now uses the shared `is_battery_charging` helper.

Since that helper is tri-state, `HoymilesBinarySensor.is_on` no longer wraps the result in `bool(...)` — a `None` is passed through as unknown, which matches the `bool | None` return type the platform already declares. The other `value_fn`s always return a real bool, so nothing else changes. The now-unused local `safe_float` helper was removed.

### 3. Idle battery reports unknown
When the `flows` array is present but contains no battery node, the battery is idle. Previously the code fell through to the old `bms_power > 0` test and reported "charging". It now returns `None` (→ `unknown`) in that case. The legacy fallback is deliberately kept when there is **no** `flows` array at all, so accounts on older/different firmware do not regress.

`get_signed_battery_power` still returns the unsigned magnitude when no direction is available (it is ~0 at idle) rather than dropping the sensor to unknown, to avoid gaps in long-term statistics.

### 4. Tests
New tests in `tests/test_data.py` using the standalone loader (no Home Assistant needed): charging (`in: 10`), discharging (`out: 10`), flows without a battery node, empty flows list, absent `flows` key, missing/placeholder `bms_power`, and non-list / non-dict-entry `flows`.

### 5. Version, docs and #49 nits
- `manifest.json` bumped 1.1.0 → **1.2.0**. This is a user-visible breaking change: `battery_power` flips sign for existing installs.
- `README.md` documents the sign convention (positive = discharging, negative = charging) and calls out the upgrade impact on dashboards, automations and existing statistics.
- `translations/en.json`: the `battery_power` `direction` attribute description said "positive = charging" — inverted under the new convention — and `battery_flow_direction` had no `unknown` state. Both fixed.
- `const.py`: `INDICATOR_FLOW_STAT_TYPE_LOAD/_GRID/_PV` are unused; kept with a comment explaining they document the API's node-type enum.
- `sensor.py`: the `.data` import block is alphabetised again.

## Validation

`pytest -q` from the repo root: **65 passed** (7 new). No Home Assistant installed, per `AGENTS.md`.

Not validated against a live account — the flow semantics are taken from #49's reporter. Reviewers with a battery station may want to confirm that an idle battery now shows `unknown` rather than `charging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)