### PR TITLE
fix(battery): restore working reserve SOC / battery mode writes

### DIFF
--- a/custom_components/hoymiles_cloud/__init__.py
+++ b/custom_components/hoymiles_cloud/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -375,8 +376,81 @@ async def _async_unregister_services(hass: HomeAssistant) -> None:
     hass.data.get(DOMAIN, {}).pop("services_registered", None)
 
 
+# Reserve-SOC entities were originally keyed by a slugified mode name and are
+# now keyed by the numeric mode id. Without a migration Home Assistant keeps the
+# old entry registered and gives the new entity a "_2" suffix, leaving users
+# with a dead duplicate and silently broken automations - see issue #43.
+LEGACY_RESERVE_SOC_MODE_SLUGS = {
+    "self-consumption_mode": 1,
+    "economy_mode": 2,
+    "backup_mode": 3,
+    "off-grid_mode": 4,
+    "self-consumption_+_max_power_mode": 5,
+    "backup_+_max_power_mode": 6,
+    "peak_shaving_mode": 7,
+    "time_of_use_mode": 8,
+}
+
+
+def _legacy_reserve_soc_mode(unique_id: str) -> int | None:
+    """Return the mode id a legacy slug-keyed reserve SOC unique id refers to."""
+    marker = "_battery_reserve_soc_"
+    if marker not in unique_id:
+        return None
+    _, _, suffix = unique_id.rpartition(marker)
+    return LEGACY_RESERVE_SOC_MODE_SLUGS.get(suffix)
+
+
+async def _async_migrate_reserve_soc_entities(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    """Retire legacy slug-keyed reserve SOC entities.
+
+    Two situations exist. If the modern mode-id entity was never created the
+    legacy entry is renamed onto the new unique id, keeping the user's history
+    and automations. If both exist - the common case, because the rename shipped
+    without a migration and Home Assistant then suffixed the new entity with
+    "_2" - the legacy entry is a dead duplicate and is removed.
+    """
+    registry = er.async_get(hass)
+    entries = er.async_entries_for_config_entry(registry, entry.entry_id)
+    known_unique_ids = {item.unique_id for item in entries}
+
+    for item in entries:
+        if item.domain != "number" or not item.unique_id:
+            continue
+        mode = _legacy_reserve_soc_mode(item.unique_id)
+        if mode is None:
+            continue
+
+        marker = "_battery_reserve_soc_"
+        prefix, _, _ = item.unique_id.rpartition(marker)
+        new_unique_id = f"{prefix}{marker}{mode}"
+
+        if new_unique_id in known_unique_ids:
+            _LOGGER.info(
+                "Removing superseded reserve SOC entity %s (unique id %s); "
+                "it was replaced by the mode-id keyed entity",
+                item.entity_id,
+                item.unique_id,
+            )
+            registry.async_remove(item.entity_id)
+            continue
+
+        _LOGGER.info(
+            "Migrating reserve SOC entity %s from unique id %s to %s",
+            item.entity_id,
+            item.unique_id,
+            new_unique_id,
+        )
+        registry.async_update_entity(item.entity_id, new_unique_id=new_unique_id)
+        known_unique_ids.add(new_unique_id)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Hoymiles Cloud from a config entry."""
+    await _async_migrate_reserve_soc_entities(hass, entry)
+
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)

--- a/custom_components/hoymiles_cloud/data.py
+++ b/custom_components/hoymiles_cloud/data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from copy import deepcopy
 from datetime import datetime, timedelta
 import json
+import logging
 from typing import Any
 
 from .const import (
@@ -19,6 +20,8 @@ from .const import (
     MODULE_DATA_PRECISION,
 )
 
+
+_LOGGER = logging.getLogger(__name__)
 
 MODE_KEY_MAPPING = {
     1: "k_1",
@@ -617,6 +620,16 @@ def get_allowed_battery_modes(
         if isinstance(mode, (int, float, str)) and str(mode).strip().isdigit()
     }
     allowed = [mode for mode in supported_modes if mode in restricted_modes]
+    if allowed and len(allowed) != len(supported_modes):
+        # ctl_mode_set semantics are not fully verified (see the open questions
+        # in docs/hoymiles-battery-mode-api.md). Record what it removes so a
+        # user reporting a missing control can be diagnosed - see issue #43.
+        _LOGGER.debug(
+            "ctl_mode_set %s hid battery modes %s from the supported set %s",
+            sorted(restricted_modes),
+            [mode for mode in supported_modes if mode not in restricted_modes],
+            supported_modes,
+        )
     return allowed or supported_modes
 
 

--- a/custom_components/hoymiles_cloud/diagnostics.py
+++ b/custom_components/hoymiles_cloud/diagnostics.py
@@ -28,6 +28,11 @@ except ImportError:  # pragma: no cover - enables pure unit tests without Home A
         return _redact(data)
 
 from .const import CONF_APP_VERSION, CONF_AUTH_MODE, DOMAIN
+from .data import (
+    get_allowed_battery_modes,
+    get_backend_modes,
+    get_supported_modes,
+)
 
 REDACT_KEYS = {
     "address",
@@ -75,6 +80,14 @@ def _station_summary(station_data: dict[str, Any]) -> dict[str, Any]:
             "meters": devices.get("meters", []),
         },
         "setting_rules": station_data.get("setting_rules", {}),
+        "battery_mode_gating": {
+            "backend_modes": get_backend_modes(station_data.get("battery_settings")),
+            "supported_modes": get_supported_modes(station_data.get("battery_settings")),
+            "allowed_modes": get_allowed_battery_modes(
+                station_data.get("battery_settings"),
+                station_data.get("setting_rules"),
+            ),
+        },
         "capabilities": station_data.get("capabilities", {}),
         "battery_settings": _redact_schedule_shapes(station_data.get("battery_settings", {})),
         "relay_settings": _redact_schedule_shapes(station_data.get("relay_settings", {})),

--- a/custom_components/hoymiles_cloud/hoymiles_api.py
+++ b/custom_components/hoymiles_cloud/hoymiles_api.py
@@ -1449,8 +1449,28 @@ class HoymilesAPI:
                 "data": deepcopy(mode_settings),
             },
         )
+        _LOGGER.debug(
+            "Direct battery write response for station %s mode %s: %s",
+            station_id,
+            mode,
+            json.dumps(response, default=str),
+        )
+
         if response.get("status") == "0" and response.get("message") == "success":
-            return bool(response.get("data", True))
+            # The endpoint is undocumented and its ``data`` field has been
+            # observed carrying values that are falsy but not a failure (null,
+            # 0, ""). Only an explicit ``False`` means the write was rejected;
+            # anything else alongside a success status is a success. Treating
+            # falsy data as failure made the write look like it silently did
+            # nothing - see issue #43.
+            if response.get("data") is False:
+                _LOGGER.error(
+                    "Direct battery write for station %s mode %s was rejected by the API",
+                    station_id,
+                    mode,
+                )
+                return False
+            return True
 
         _LOGGER.error(
             "Failed direct battery write for station %s mode %s: %s - %s",
@@ -1460,6 +1480,28 @@ class HoymilesAPI:
             response.get("message"),
         )
         return False
+
+    async def apply_battery_mode_payload(
+        self, station_id: str, mode: int, mode_settings: dict[str, Any]
+    ) -> bool:
+        """Write a battery mode payload, falling back to the async job flow.
+
+        Two transports exist. The direct endpoint is fast but undocumented; the
+        action-based flow (write -> job id -> status poll) is the one captured in
+        ``docs/hoymiles-battery-mode-api.md`` and is what the web UI uses. Some
+        accounts stopped accepting the direct write (issue #43), so a failure
+        there is retried through the documented flow before giving up.
+        """
+        if await self.set_battery_config_direct(station_id, mode, mode_settings):
+            return True
+
+        _LOGGER.debug(
+            "Direct battery write failed for station %s mode %s, "
+            "retrying via the async settings job flow",
+            station_id,
+            mode,
+        )
+        return await self._write_battery_mode_payload(station_id, mode, mode_settings)
 
     async def _write_battery_mode_payload(
         self, station_id: str, mode: int, mode_settings: dict[str, Any]
@@ -1617,7 +1659,7 @@ class HoymilesAPI:
             mode_settings.setdefault("money_code", "$")
             mode_settings.setdefault("date", [])
 
-        return await self.set_battery_config_direct(station_id, mode, mode_settings)
+        return await self.apply_battery_mode_payload(station_id, mode, mode_settings)
 
     async def set_battery_mode(self, station_id: str, mode: int) -> bool:
         """Set battery mode for a station."""
@@ -1634,7 +1676,7 @@ class HoymilesAPI:
             BATTERY_MODES.get(mode),
             station_id,
         )
-        return await self.set_battery_config_direct(station_id, mode, mode_settings)
+        return await self.apply_battery_mode_payload(station_id, mode, mode_settings)
 
     async def set_reserve_soc(self, station_id: str, reserve_soc: int) -> bool:
         """Set battery reserve SOC for a station."""

--- a/custom_components/hoymiles_cloud/number.py
+++ b/custom_components/hoymiles_cloud/number.py
@@ -7,6 +7,7 @@ from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
@@ -287,7 +288,10 @@ class HoymilesBatteryReserveSOC(HoymilesBatteryNumberEntity):
             self._mode,
             {"reserve_soc": int(value)},
         ):
-            return
+            raise HomeAssistantError(
+                f"Hoymiles rejected the reserve SOC update for {self._mode_name}. "
+                "See the Home Assistant log for the API response."
+            )
 
         await self._update_soc(self._station_id, self._get_storage_key(), int(value))
         await self.coordinator.async_request_refresh()
@@ -330,7 +334,10 @@ class HoymilesBatteryMaxPower(HoymilesBatteryNumberEntity):
             self._mode,
             {"max_power": float(value)},
         ):
-            return
+            raise HomeAssistantError(
+                f"Hoymiles rejected the max power update for {self._mode_name}. "
+                "See the Home Assistant log for the API response."
+            )
 
         await self.coordinator.async_request_refresh()
         self.async_write_ha_state()
@@ -375,7 +382,10 @@ class HoymilesPeakShavingMaxSOC(HoymilesBatteryNumberEntity):
             max_soc=int(value),
             meter_power=current_settings.get("meter_power"),
         ):
-            return
+            raise HomeAssistantError(
+                "Hoymiles rejected the Peak Shaving max SOC update. "
+                "See the Home Assistant log for the API response."
+            )
 
         await self.coordinator.async_request_refresh()
         self.async_write_ha_state()
@@ -420,7 +430,10 @@ class HoymilesPeakShavingMeterPower(HoymilesBatteryNumberEntity):
             max_soc=current_settings.get("max_soc"),
             meter_power=int(value),
         ):
-            return
+            raise HomeAssistantError(
+                "Hoymiles rejected the Peak Shaving meter power update. "
+                "See the Home Assistant log for the API response."
+            )
 
         await self.coordinator.async_request_refresh()
         self.async_write_ha_state()

--- a/tests/test_hoymiles_api.py
+++ b/tests/test_hoymiles_api.py
@@ -786,3 +786,97 @@ def test_get_module_channel_data_rounds_float32_noise() -> None:
     )
 
     assert values == {"MODULE_POWER": 140.9, "MODULE_V": 35.3, "MODULE_I": 3.98}
+
+
+def _read_battery_settings_responses(mode: int, mode_key: str) -> list[dict]:
+    """Return the two responses of a battery-settings read job."""
+    return [
+        {"status": "0", "message": "success", "data": "read-job"},
+        {
+            "status": "0",
+            "message": "success",
+            "data": {
+                "code": 0,
+                "data": {"mode": mode, "data": {mode_key: {"reserve_soc": 10}}},
+            },
+        },
+    ]
+
+
+@pytest.mark.parametrize("falsy_data", [None, 0, "", {}, []])
+def test_direct_battery_write_accepts_success_with_falsy_data(falsy_data) -> None:
+    """A success status must not be read as failure because ``data`` is falsy.
+
+    The direct endpoint is undocumented and has been observed returning success
+    with an empty ``data`` field; treating that as a failure made writes look
+    like they silently did nothing (issue #43).
+    """
+    session = FakeSession(
+        _read_battery_settings_responses(1, "k_1")
+        + [{"status": "0", "message": "success", "data": falsy_data}]
+    )
+    api = HoymilesAPI(session, "user@example.com", "secret")
+    api._token = "token"
+    api._token_expires_at = 9999999999
+
+    assert asyncio.run(api.set_battery_mode("123", 1)) is True
+    # The documented async fallback must not fire when the direct write worked.
+    assert len(session.requests) == 3
+
+
+def test_direct_battery_write_rejects_explicit_false_and_falls_back() -> None:
+    """``data: False`` is a real rejection, which then triggers the fallback."""
+    session = FakeSession(
+        _read_battery_settings_responses(1, "k_1")
+        + [
+            {"status": "0", "message": "success", "data": False},
+            # fallback: async write job, then its status poll
+            {"status": "0", "message": "success", "data": "write-job"},
+            {"status": "0", "message": "success", "data": {"code": 0}},
+        ]
+    )
+    api = HoymilesAPI(session, "user@example.com", "secret")
+    api._token = "token"
+    api._token_expires_at = 9999999999
+
+    assert asyncio.run(api.set_battery_mode("123", 1)) is True
+    assert len(session.requests) == 5
+
+
+def test_battery_write_falls_back_to_async_job_flow() -> None:
+    """A failing direct write is retried through the documented job flow."""
+    session = FakeSession(
+        _read_battery_settings_responses(1, "k_1")
+        + [
+            {"status": "1", "message": "failed", "data": None},
+            {"status": "0", "message": "success", "data": "write-job"},
+            {"status": "0", "message": "success", "data": {"code": 0}},
+        ]
+    )
+    api = HoymilesAPI(session, "user@example.com", "secret")
+    api._token = "token"
+    api._token_expires_at = 9999999999
+
+    assert asyncio.run(api.set_battery_mode("123", 1)) is True
+
+    # The fallback must use the documented action-1013 payload shape.
+    fallback_payload = session.requests[3]["kwargs"]["json"]
+    assert fallback_payload["action"] == 1013
+    assert fallback_payload["data"]["sid"] == 123
+    assert fallback_payload["data"]["data"]["mode"] == 1
+
+
+def test_battery_write_reports_failure_when_both_transports_fail() -> None:
+    """Both transports failing must still surface as a failed write."""
+    session = FakeSession(
+        _read_battery_settings_responses(1, "k_1")
+        + [
+            {"status": "1", "message": "failed", "data": None},
+            {"status": "1", "message": "failed", "data": None},
+        ]
+    )
+    api = HoymilesAPI(session, "user@example.com", "secret")
+    api._token = "token"
+    api._token_expires_at = 9999999999
+
+    assert asyncio.run(api.set_battery_mode("123", 1)) is False


### PR DESCRIPTION
Closes #43

Battery controls stopped responding after an update: the slider snaps back and nothing reaches the cloud. @jOma92 is the same user who confirmed these controls working again in #31 right after `127b967` (v0.5.0), which narrows the regression to the `641d51e` redesign that followed. Three defects on that path, all from that commit.

### 1. Successful writes reported as failures

```python
return bool(response.get("data", True))
```

A response with `status: "0"` / `message: "success"` but a falsy `data` (`null`, `0`, `""`) was treated as a failure — the entity then returned early, never refreshed, and the slider bounced back. The endpoint is undocumented and its response shape was never verified; the only test coverage fed `data: True`.

Now only an explicit `data: False` counts as a rejection, and the raw body is logged at debug so we can finally record the real shape in the docs.

### 2. The documented write transport had become dead code

`641d51e` switched writes from the action-1013 job flow (write → job id → status poll) — the flow captured in `docs/hoymiles-battery-mode-api.md` and mandated by AGENTS.md — to `/pvm/api/0/station/setting/battery_config`, an endpoint that appears **nowhere** in `docs/`. `_write_battery_mode_payload` was left defined but called from nowhere.

Writes now try the direct endpoint and **fall back to the documented job flow** on failure. I kept the direct endpoint as the primary path deliberately: it has been working for most users for months, and I have no account that reproduces the failure, so silently switching everyone back to the old transport would risk trading one regression for another.

### 3. Write failures were invisible

The number entities returned silently on failure, which is exactly why the symptom is "the slider snaps back" with nothing in the log. They now raise `HomeAssistantError`, so the user gets an actual error. Applied to reserve SOC, max power, and both Peak Shaving controls.

### Plus: retire the orphaned legacy entities

This explains the odd entity name in the report. `number.battery_reserve_soc_self_consumption_mode_2` is **Self-Consumption (mode 1)** — the `_2` is Home Assistant's duplicate-name counter, not a mode number. Reserve-SOC unique ids changed from a slugified mode name to the numeric mode id with no migration, so HA registered the new entity alongside the old one and suffixed it. Any automation still pointing at the un-suffixed id has been a silent no-op since then.

`_async_migrate_reserve_soc_entities` handles both cases: rename when only the legacy entry exists (preserving history), remove the orphan when both do. The second case is the common one, and a naive `async_migrate_entries` rename would have collided there.

### Plus: make `ctl_mode_set` observable

`641d51e` also started filtering modes through `setting_rule.ctl_mode_set`, whose semantics our own docs still list as an open question. If it hides a mode, the control is never created — indistinguishable from a failed write. It now logs what it removes and exposes `battery_mode_gating` (backend / supported / allowed modes) in diagnostics.

### Testing

`pytest -q` → **65 passed** (8 new, parametrised over the falsy-`data` shapes): success-with-falsy-data, explicit-`False` rejection, fallback firing and using the correct action-1013 payload, and both transports failing.

### Not verified against hardware

I have no account that reproduces the original failure, so which of defects 1 and 2 was actually biting @jOma92 is unconfirmed — this fixes both, plus the reporting gap that hid whichever it was. I have asked on #43 for a debug log and diagnostics; if those show the direct endpoint returning success all along, defect 1 was the cause and the fallback is belt-and-braces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)