### PR TITLE
fix(sensor): withhold negative readings from total_increasing counters

### DIFF
--- a/custom_components/hoymiles_cloud/data.py
+++ b/custom_components/hoymiles_cloud/data.py
@@ -807,6 +807,26 @@ def merge_missing_pv_channel_values(
     return merged
 
 
+def is_invalid_total_increasing(value: Any, total_increasing: bool) -> bool:
+    """Return whether a value must be withheld from a total_increasing sensor.
+
+    Home Assistant treats a drop in a ``total_increasing`` sensor as a meter
+    reset, so a negative reading is not merely cosmetic: the next normal value
+    is recorded as one huge delta and permanently inflates long-term
+    statistics. The Hoymiles cloud has been observed returning negative values
+    for daily energy counters on systems where the underlying figure is derived
+    rather than metered (issue #54).
+
+    Only counters are affected. Measurements such as battery power are
+    legitimately signed and must pass through untouched.
+    """
+    if not total_increasing:
+        return False
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    return value < 0
+
+
 MODULE_DATA_QUOTAS = ("MODULE_POWER", "MODULE_V", "MODULE_I")
 
 

--- a/custom_components/hoymiles_cloud/sensor.py
+++ b/custom_components/hoymiles_cloud/sensor.py
@@ -41,6 +41,7 @@ from .data import (
     get_pv_indicator_value,
     get_schedule_modes,
     get_signed_battery_power,
+    is_invalid_total_increasing,
     get_supported_modes,
     is_battery_charging,
 )
@@ -895,6 +896,7 @@ class HoymilesAggregateSensor(HoymilesBaseSensor):
         """Initialize the sensor."""
         super().__init__(coordinator, station_id, station_name)
         self.entity_description = description
+        self._negative_value_warned = False
         station_data = self._get_station_data()
         self._attr_unique_id = f"{DOMAIN}_{station_id}_{description.key}"
         self._attr_name = f"{station_name} {description.name}"
@@ -904,16 +906,38 @@ class HoymilesAggregateSensor(HoymilesBaseSensor):
             else get_station_device_info(station_id, station_name, station_data)
         )
 
+    def _reject_negative(self, value: Any) -> None:
+        """Warn once per outage that a counter went negative, then stay quiet."""
+        message = (
+            "Ignoring negative value %s for %s, which is a total_increasing "
+            "counter; reporting it would corrupt long-term statistics"
+        )
+        if self._negative_value_warned:
+            _LOGGER.debug(message, value, self.entity_description.key)
+            return
+        self._negative_value_warned = True
+        _LOGGER.warning(message, value, self.entity_description.key)
+
     @property
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         if not self.entity_description.value_fn:
             return None
         try:
-            return self.entity_description.value_fn(self._get_station_data())
+            value = self.entity_description.value_fn(self._get_station_data())
         except Exception as err:  # pragma: no cover - defensive logging
             _LOGGER.error("Error getting sensor value for %s: %s", self.entity_description.key, err)
             return None
+
+        if is_invalid_total_increasing(
+            value,
+            self.entity_description.state_class == SensorStateClass.TOTAL_INCREASING,
+        ):
+            self._reject_negative(value)
+            return None
+
+        self._negative_value_warned = False
+        return value
 
     @property
     def available(self) -> bool:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -545,3 +545,37 @@ def test_battery_flow_direction_handles_malformed_flows() -> None:
     junk_entries = _station({"bms_power": "75", "flows": ["nonsense", None, {"out": 10, "in": 1}]})
     assert get_battery_flow_direction(junk_entries) == 1
     assert get_signed_battery_power(junk_entries) == 75.0
+
+
+def test_negative_value_rejected_for_total_increasing_counters() -> None:
+    """A negative counter reading must be withheld, not published.
+
+    Home Assistant reads a drop in a total_increasing sensor as a meter reset,
+    so publishing a negative would make the next normal reading land as one
+    huge delta and permanently inflate long-term statistics (issue #54).
+    """
+    assert data_module.is_invalid_total_increasing(-3461, True) is True
+    assert data_module.is_invalid_total_increasing(-0.5, True) is True
+
+
+def test_zero_and_positive_values_pass_through() -> None:
+    """Only negatives are rejected; zero is a legitimate counter value."""
+    assert data_module.is_invalid_total_increasing(0, True) is False
+    assert data_module.is_invalid_total_increasing(3461, True) is False
+    assert data_module.is_invalid_total_increasing(0.0, True) is False
+
+
+def test_negative_measurements_are_left_alone() -> None:
+    """Signed measurements must pass through untouched.
+
+    battery_power is legitimately negative while charging; a blanket
+    no-negatives rule would undo that.
+    """
+    assert data_module.is_invalid_total_increasing(-1200, False) is False
+
+
+def test_non_numeric_values_are_not_rejected() -> None:
+    """Unknown/None readings are handled elsewhere and must not be swallowed."""
+    assert data_module.is_invalid_total_increasing(None, True) is False
+    assert data_module.is_invalid_total_increasing("-5", True) is False
+    assert data_module.is_invalid_total_increasing(False, True) is False


### PR DESCRIPTION
Closes #54

The cloud returned `pv_to_load_eq = -3461 Wh` for @davidmcluckie's **battery-only** HiBattery 4020 X — a station with no PV at all — tripping HA's recorder warning.

### Why this is worse than a log warning

Home Assistant infers a **meter reset** when a `total_increasing` sensor drops. A negative reading therefore does not just look wrong: the next normal value is booked as one enormous delta, permanently inflating the Energy dashboard and long-term statistics. Users typically notice weeks later, when the damage is already recorded.

None of the **23** `total_increasing` sensors guarded against this — every one forwarded the cloud's value verbatim.

### The fix

A single guard in the shared `native_value`, with the predicate itself in `data.py` so it is unit-testable per AGENTS.md:

- **Returns `None`, not `max(0, value)`.** Clamping to 0 would *itself* read as a reset and cause the very inflation this prevents. `None` makes the sensor `unknown` for that poll and the recorder skips the sample, leaving statistics intact.
- **Scoped to `TOTAL_INCREASING`.** `battery_power` is `MEASUREMENT` and legitimately negative since 1.2.0 — a blanket no-negatives rule would undo that fix. Keying off the state class rules that out by construction.
- **Central**, so it covers all 23 counters and anything added later, rather than 23 edited lambdas.
- **Warn-once-per-outage**, per the AGENTS.md rule, so a persistently negative field cannot reproduce the #47 log flood.

### On the trajectory

The debug repeats log the value on every poll. That matters for deciding the *end* state: if the counter only ever rises from a negative floor it is an offset and this guard is the correct permanent fix; if it genuinely falls between polls there is real bidirectional flow, and the right answer is a pair of directional sensors with proper delta accumulation (the pattern the integration already uses for `grid_import`/`grid_export` and `battery_charge`/`battery_discharge`, where the API supplies both sides). Diagnostics now carry the raw `real_time_data` payload as of #53, so the export will show it too.

### Deliberately not in scope

The reporter's station has no PV, yet has a `PV to Load Energy Today` sensor. Gating it on PV capability may well be the deeper fix, but removing entities destroys existing users' history, and telling "no PV, genuinely zero" apart from "PV present, reading broken" needs the capability data. Not worth guessing at off one report.

`pytest -q` → **88 passed** (84 before): negative rejected, zero and positive pass, signed measurements untouched, non-numeric values not swallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)