### PR TITLE
chore: bump version to 1.2.2

### DIFF
--- a/custom_components/hoymiles_cloud/manifest.json
+++ b/custom_components/hoymiles_cloud/manifest.json
@@ -14,5 +14,5 @@
     "argon2-cffi>=21.3.0"
   ],
   "single_config_entry": false,
-  "version": "1.2.1"
+  "version": "1.2.2"
 }


### PR DESCRIPTION
Patch release covering the schema corrections and CI added in #57.

HACS requires a full GitHub release created *after* the validation actions have run successfully, so this bump exists to cut one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)