### PR TITLE
chore: gitignore the local scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 tmp/*
 .venv/
+.local/


### PR DESCRIPTION
The `.local/` directory (API exploration scripts, captures, and credential files) was untracked but **not** gitignored, so a routine `git add -A` would have committed credentials.

Nothing has ever been committed from it — `git log --all -- .local` is empty — this just closes the hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)