### PR TITLE
fix(sensor): gate EV charger power on the charging-pile flags

### DIFF
--- a/custom_components/hoymiles_cloud/const.py
+++ b/custom_components/hoymiles_cloud/const.py
@@ -211,6 +211,12 @@ INDICATOR_FLOW_STAT_TYPE_GRID = 2
 INDICATOR_FLOW_STAT_TYPE_PV = 4
 INDICATOR_FLOW_STAT_TYPE_BATTERY = 10
 
+# Keys of the live reflux payload that advertise a charging pile (EV charger).
+# The vendor app renders the charging-pile node only when one of these icon
+# flags is set; ``pile_power`` itself is emitted even by stations that have no
+# charger at all, where it does not carry charger telemetry.
+EV_CHARGER_FLAG_KEYS = ("icon_plug", "icon_ai_plug")
+
 # Energy-flow stats types
 ENERGY_FLOW_STAT_TYPE_OVERVIEW = 1
 ENERGY_FLOW_STAT_TYPE_BATTERY = 4

--- a/custom_components/hoymiles_cloud/data.py
+++ b/custom_components/hoymiles_cloud/data.py
@@ -14,6 +14,7 @@ from .const import (
     BATTERY_MODE_IDS,
     BATTERY_MODE_TIME_OF_USE,
     BATTERY_SCHEDULE_MODE_IDS,
+    EV_CHARGER_FLAG_KEYS,
     INDICATOR_FLOW_STAT_TYPE_BATTERY,
     METER_LOCATION_NAMES,
     MODULE_DATA_MAX_AGE_MINUTES,
@@ -1000,6 +1001,56 @@ def is_battery_charging(station_data: dict[str, Any] | None) -> bool | None:
     return None
 
 
+def _ev_charger_flags(reflux_data: dict[str, Any]) -> list[Any]:
+    """Return the charging-pile icon flags the payload actually carries."""
+    return [reflux_data[key] for key in EV_CHARGER_FLAG_KEYS if key in reflux_data]
+
+
+def _flag_is_set(value: Any) -> bool:
+    """Return whether an API icon flag is set, tolerating string encodings."""
+    number = _optional_float(value)
+    if number is None:
+        return bool(value)
+    return number != 0
+
+
+def has_ev_charger(station_data: dict[str, Any] | None) -> bool:
+    """Return whether the station advertises a charging pile.
+
+    ``pile_power`` is present in the reflux payload of stations that have no EV
+    charger at all, where it does not carry charger telemetry (issue #64: it
+    mirrored PV power on a station with no vehicle connected). The vendor app
+    gates the charging-pile node on the ``icon_plug``/``icon_ai_plug`` flags, so
+    the same gate is applied here. Payloads that carry neither flag keep the
+    previous behaviour, so stations on older firmware do not lose the entity.
+    """
+    reflux_data = _reflux_data(station_data)
+    if _optional_float(reflux_data.get("pile_power")) is None:
+        return False
+    flags = _ev_charger_flags(reflux_data)
+    if not flags:
+        return True
+    return any(_flag_is_set(flag) for flag in flags)
+
+
+def get_ev_charger_power(station_data: dict[str, Any] | None) -> float | None:
+    """Return EV charger power, or 0 W when no charging pile is active.
+
+    The station keeps reporting a ``pile_power`` value while the icon flags say
+    no pile is connected; that value is not charger telemetry, so it is replaced
+    by an explicit 0 rather than published or dropped. Keeping the entity at 0
+    (instead of unavailable) avoids gaps in long-term statistics.
+    """
+    reflux_data = _reflux_data(station_data)
+    power = _optional_float(reflux_data.get("pile_power"))
+    if power is None:
+        return None
+    flags = _ev_charger_flags(reflux_data)
+    if flags and not any(_flag_is_set(flag) for flag in flags):
+        return 0.0
+    return power
+
+
 def has_battery_telemetry(real_time_data: dict[str, Any] | None) -> bool:
     """Return whether real-time data contains battery telemetry."""
     reflux_data = (real_time_data or {}).get("reflux_station_data", {})
@@ -1042,6 +1093,7 @@ def build_station_capabilities(
 
     return {
         "battery_telemetry": has_battery_telemetry(real_time_data),
+        "ev_charger_available": has_ev_charger({"real_time_data": real_time_data or {}}),
         "battery_settings_readable": battery_settings_readable(battery_settings),
         "battery_settings_writable": battery_settings_writable(battery_settings),
         "relay_settings_readable": relay_settings_readable(relay_settings),

--- a/custom_components/hoymiles_cloud/manifest.json
+++ b/custom_components/hoymiles_cloud/manifest.json
@@ -14,5 +14,5 @@
     "argon2-cffi>=21.3.0"
   ],
   "single_config_entry": false,
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/custom_components/hoymiles_cloud/sensor.py
+++ b/custom_components/hoymiles_cloud/sensor.py
@@ -36,6 +36,7 @@ from .data import (
     discover_pv_channels,
     get_allowed_battery_modes,
     get_energy_flow_value,
+    get_ev_charger_power,
     get_indicator_value,
     get_mode_settings,
     get_pv_indicator_value,
@@ -43,6 +44,7 @@ from .data import (
     get_signed_battery_power,
     is_invalid_total_increasing,
     get_supported_modes,
+    has_ev_charger,
     is_battery_charging,
 )
 from .device import (
@@ -189,6 +191,9 @@ class HoymilesSensorDescription(SensorEntityDescription):
 
     value_fn: Callable[[dict[str, Any]], StateType] | None = None
     exists_fn: Callable[[dict[str, Any]], bool] | None = None
+    # Defaults to ``exists_fn``. Set it when an entity should be created
+    # only under a narrow condition but must stay available afterwards.
+    available_fn: Callable[[dict[str, Any]], bool] | None = None
     device_info_fn: Callable[[str, str, dict[str, Any]], dict[str, Any]] | None = None
 
 
@@ -461,8 +466,9 @@ STATION_SENSORS: list[HoymilesSensorDescription] = [
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        exists_fn=lambda data: safe_float_convert(get_reflux_data(data).get("pile_power")) is not None,
-        value_fn=lambda data: safe_float_convert(get_reflux_data(data).get("pile_power")),
+        exists_fn=has_ev_charger,
+        available_fn=lambda data: safe_float_convert(get_reflux_data(data).get("pile_power")) is not None,
+        value_fn=get_ev_charger_power,
     ),
     HoymilesSensorDescription(
         key="self_consumption_rate",
@@ -944,8 +950,9 @@ class HoymilesAggregateSensor(HoymilesBaseSensor):
         """Return if entity is available."""
         if not self.coordinator.last_update_success:
             return False
-        if self.entity_description.exists_fn:
-            return self.entity_description.exists_fn(self._get_station_data())
+        available_fn = self.entity_description.available_fn or self.entity_description.exists_fn
+        if available_fn:
+            return available_fn(self._get_station_data())
         return bool(self._get_station_data())
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -16,7 +16,9 @@ find_placeholder_pv_channels = data_module.find_placeholder_pv_channels
 get_allowed_battery_modes = data_module.get_allowed_battery_modes
 get_battery_flow_direction = data_module.get_battery_flow_direction
 get_schedule_modes = data_module.get_schedule_modes
+get_ev_charger_power = data_module.get_ev_charger_power
 get_signed_battery_power = data_module.get_signed_battery_power
+has_ev_charger = data_module.has_ev_charger
 is_battery_charging = data_module.is_battery_charging
 latest_module_values = data_module.latest_module_values
 merge_missing_pv_channel_values = data_module.merge_missing_pv_channel_values
@@ -579,3 +581,67 @@ def test_non_numeric_values_are_not_rejected() -> None:
     assert data_module.is_invalid_total_increasing(None, True) is False
     assert data_module.is_invalid_total_increasing("-5", True) is False
     assert data_module.is_invalid_total_increasing(False, True) is False
+
+
+def _station_with_reflux(**reflux: object) -> dict:
+    """Build a station payload carrying the given reflux fields."""
+    return {"real_time_data": {"reflux_station_data": reflux}}
+
+
+def test_ev_charger_hidden_when_no_pile_is_advertised() -> None:
+    """A station without a charging pile must not get the sensor.
+
+    pile_power is emitted regardless of whether a charger exists, and on a
+    station without one it mirrored PV power (issue #64). The icon flags are
+    what the vendor app gates the charging-pile node on.
+    """
+    station = _station_with_reflux(pile_power="742", icon_plug=0, icon_ai_plug=0)
+
+    assert has_ev_charger(station) is False
+
+
+def test_ev_charger_power_reports_zero_while_no_pile_is_connected() -> None:
+    """The mirrored value is replaced by 0 W, not published or dropped."""
+    station = _station_with_reflux(pile_power="742", icon_plug=0, icon_ai_plug=0)
+
+    assert get_ev_charger_power(station) == 0.0
+
+
+def test_ev_charger_exposed_when_a_pile_is_advertised() -> None:
+    """Either icon flag is enough to treat pile_power as charger telemetry."""
+    plain = _station_with_reflux(pile_power="3600", icon_plug=1, icon_ai_plug=0)
+    ai = _station_with_reflux(pile_power="3600", icon_plug="0", icon_ai_plug="1")
+
+    assert has_ev_charger(plain) is True
+    assert get_ev_charger_power(plain) == 3600.0
+    assert has_ev_charger(ai) is True
+    assert get_ev_charger_power(ai) == 3600.0
+
+
+def test_ev_charger_keeps_legacy_behaviour_without_icon_flags() -> None:
+    """Payloads that carry neither flag must not lose the entity."""
+    station = _station_with_reflux(pile_power="3600")
+
+    assert has_ev_charger(station) is True
+    assert get_ev_charger_power(station) == 3600.0
+
+
+def test_ev_charger_absent_without_pile_power() -> None:
+    """No pile_power at all means there is nothing to report."""
+    assert has_ev_charger(_station_with_reflux(icon_plug=1)) is False
+    assert has_ev_charger(_station_with_reflux(pile_power="-")) is False
+    assert get_ev_charger_power(_station_with_reflux()) is None
+
+
+def test_capabilities_report_ev_charger_availability() -> None:
+    """Diagnostics should show whether the charger sensor was created."""
+    real_time_data = {"reflux_station_data": {"pile_power": "742", "icon_plug": 0}}
+
+    capabilities = build_station_capabilities(
+        real_time_data=real_time_data,
+        pv_indicators={},
+        battery_settings={},
+        microinverters_data={},
+    )
+
+    assert capabilities["ev_charger_available"] is False


### PR DESCRIPTION
Fixes #64.

## Problem

`sensor.<station>_ev_charger_power` read `pile_power` from the reflux payload with no gate beyond "is it parseable". The reporter's station has no vehicle connected, the vendor app shows 0 W, and HA showed a value exactly matching current PV production.

The reporter's reading of the code was correct: `pile_power` is present in the reflux payload of stations that have no charging pile at all, and there it does not carry charger telemetry. The same payload also carries `icon_plug` / `icon_ai_plug`, which is what the vendor app gates the charging-pile node on — both are `0` in the diagnostics I have from stations without a charger.

## Change

- `has_ev_charger()` — the entity is created only when `pile_power` parses **and** the payload does not explicitly say there is no pile. Payloads carrying neither icon flag keep the previous behaviour, so stations on firmware that predates the flags do not lose the entity.
- `get_ev_charger_power()` — if the flags clear while the entity exists, the sensor reports an explicit `0` rather than the meaningless value.
- `available_fn` on `HoymilesSensorDescription`, defaulting to `exists_fn`. Without it the existence gate would double as the availability gate, so a station with a *real* charger would flap to `unavailable` whenever the pile disconnected, leaving gaps in long-term statistics. Now it stays available and reads 0 W.
- `capabilities.ev_charger_available` so diagnostics show whether the entity was created.

## Validation

`pytest -q` — 90 passed, including 6 new cases covering: no pile advertised, mirrored value replaced by 0, either flag sufficient (int and string encodings), legacy payloads without flags, missing/placeholder `pile_power`, and the capability flag.

Not yet confirmed against the reporter's own station — I have no diagnostics from a station that actually has a charger, so the assumption that `icon_plug` is set for one is inferred from the app's behaviour rather than observed. Levy3103 offered a diagnostics dump; that would confirm it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)