### PR TITLE
fix(sensor): derive PV channels from the microinverter port count

### DIFF
--- a/custom_components/hoymiles_cloud/__init__.py
+++ b/custom_components/hoymiles_cloud/__init__.py
@@ -46,6 +46,7 @@ from .data import (
     get_schedule_draft,
     merge_missing_pv_channel_values,
     remove_schedule_entry,
+    seed_missing_pv_channels,
     set_schedule_editor_selection,
     update_schedule_editor_draft,
 )
@@ -677,6 +678,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
                     microinverters = static_payload.get("devices", {}).get(
                         "microinverters", {}
+                    )
+                    # Channels the feed omits entirely are seeded from the
+                    # microinverter's own port count, so the fallback below can
+                    # fill them like any other placeholder (issue #39).
+                    pv_indicators = seed_missing_pv_channels(
+                        pv_indicators, microinverters
                     )
                     placeholder_channels = find_placeholder_pv_channels(pv_indicators)
                     if placeholder_channels and len(microinverters) == 1:

--- a/custom_components/hoymiles_cloud/data.py
+++ b/custom_components/hoymiles_cloud/data.py
@@ -752,6 +752,80 @@ def find_placeholder_pv_channels(pv_indicators: dict[str, Any] | None) -> list[i
     return channels
 
 
+def get_microinverter_port_count(microinverter: Any) -> int | None:
+    """Return the port count a microinverter detail payload declares.
+
+    The detail payload from ``/dev/micro/find`` carries ``rule.port`` — the
+    number of DC inputs the hardware has. This is the only field we fetch that
+    states a port count, and it is per-device, matching the ``port`` the
+    module-data endpoint takes.
+    """
+    if not isinstance(microinverter, dict):
+        return None
+    rule = microinverter.get("rule")
+    if not isinstance(rule, dict):
+        return None
+    port = rule.get("port")
+    if isinstance(port, str):
+        port = port.strip()
+        if not port.isdigit():
+            return None
+        port = int(port)
+    if isinstance(port, bool) or not isinstance(port, int) or port < 1:
+        return None
+    return port
+
+
+def expected_pv_channels(microinverters: dict[str, Any] | None) -> list[int]:
+    """Return the PV channels a station's microinverter inventory implies.
+
+    Some firmware omits a channel from the indicators feed entirely rather than
+    reporting it as a placeholder (issue #39), so the channel list cannot be
+    derived from that feed alone. The microinverter's own port count can carry
+    it instead, but only where ``channel N == port N`` is sound — that is, on a
+    single-microinverter station, the same assumption the module-data fallback
+    already rests on. With several microinverters the station-level channel
+    numbering is unknown (#56), so nothing is claimed rather than guessed.
+    """
+    if not microinverters or len(microinverters) != 1:
+        return []
+    port_count = get_microinverter_port_count(next(iter(microinverters.values())))
+    if port_count is None:
+        return []
+    return list(range(1, port_count + 1))
+
+
+def seed_missing_pv_channels(
+    pv_indicators: dict[str, Any] | None,
+    microinverters: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Add placeholder v/i/p entries for channels the feed never reports.
+
+    Seeding turns "channel absent" into "channel present but unset", which is
+    the state ``find_placeholder_pv_channels`` already looks for, so the
+    module-data fallback can fill it like any other placeholder. A channel that
+    the fallback cannot fill stays unset and reads as unknown — visibly missing
+    rather than silently wrong.
+    """
+    if not pv_indicators or not pv_indicators.get("list"):
+        # An empty feed means the fetch failed, not that channels are missing.
+        return pv_indicators or {}
+    expected = expected_pv_channels(microinverters)
+    if not expected:
+        return pv_indicators
+    known = set(discover_pv_channels(pv_indicators))
+    missing = [channel for channel in expected if channel not in known]
+    if not missing:
+        return pv_indicators
+
+    seeded = deepcopy(pv_indicators)
+    items = seeded.setdefault("list", [])
+    for channel in missing:
+        for metric in ("v", "i", "p"):
+            items.append({"key": f"{channel}_pv_{metric}", "val": None})
+    return seeded
+
+
 def _replace_indicator_value(
     items: list[dict[str, Any]],
     key: str,
@@ -1056,6 +1130,11 @@ def build_station_capabilities(
         "ai_available": bool(ai_status),
         "firmware_available": bool(firmware),
         "pv_channels": pv_channels,
+        "expected_pv_channels": expected_pv_channels(microinverters_data),
+        "microinverter_port_counts": {
+            str(mi_id): get_microinverter_port_count(micro)
+            for mi_id, micro in (microinverters_data or {}).items()
+        },
         "microinverter_details_available": bool(microinverters_data),
         "microinverter_detail_count": len(microinverters_data or {}),
         "has_dtu": bool(devices.get("dtus")),

--- a/docs/hoymiles-module-data-api.md
+++ b/docs/hoymiles-module-data-api.md
@@ -66,6 +66,54 @@ Assistant and the cloud) counts as current, and a response without a usable
 `x_axis` keeps its raw sample so hardware variants that omit the labels still
 work.
 
+## Determining which channels exist
+
+The `port` in `mi_list` is a **per-microinverter** port number, while the PV
+indicators feed exposes **station-level** channel numbers (`1_pv_v`, `2_pv_p`,
+…). Nothing we fetch states how one maps to the other, so the fallback only
+runs where `channel N == port N` is sound — a station with exactly one
+microinverter (issue #56).
+
+The channel list itself cannot come from the indicators feed alone. On some
+firmware a port is omitted from the feed entirely rather than reported with a
+placeholder value, so there is no key to discover and nothing to fill. Observed
+on an HMS-800-2WB (DTU `V01.03.04`, microinverter `V01.03.01`, issue #39):
+
+```json
+"microinverters": {
+  "33820520": {
+    "init_hard_no": "HMS-800-2WB",
+    "rule": { "dev_type": 3, "port": 2 }
+  }
+},
+"pv_indicators": {
+  "pv_total": 1,
+  "list": [
+    { "key": "pv_p_total", "val": 26.1 },
+    { "key": "1_pv_v", "val": 32.7 },
+    { "key": "1_pv_i", "val": 0.8 },
+    { "key": "1_pv_p", "val": 26.1 }
+  ]
+}
+```
+
+`rule.port` in the microinverter detail payload (`/dev/micro/find`, stored
+wholesale in `microinverters[id]`) is the authoritative port count — here `2`,
+against a feed advertising one channel and a `pv_total` of `1`. Note that
+`pv_total` agrees with the truncated feed, not with the hardware, so it is not
+usable for this.
+
+`data.expected_pv_channels()` therefore derives `1..rule.port` from that
+payload, and `data.seed_missing_pv_channels()` inserts placeholder `v`/`i`/`p`
+entries for any channel the feed omits. The omitted channel then looks like any
+other placeholder and is filled by the fallback above. A channel that cannot be
+filled stays unset and reads as unknown rather than borrowing another channel's
+value.
+
+Both functions return nothing for a multi-microinverter station: the mapping
+there is still unknown, and guessing it is the failure mode #53 introduced and
+had to revert.
+
 ## Polling cost
 
 The cloud refreshes plant telemetry only every ~5 minutes, so the coordinator

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -12,15 +12,18 @@ build_schedule_editor_state = data_module.build_schedule_editor_state
 build_schedule_payload_from_draft = data_module.build_schedule_payload_from_draft
 build_station_capabilities = data_module.build_station_capabilities
 discover_pv_channels = data_module.discover_pv_channels
+expected_pv_channels = data_module.expected_pv_channels
 find_placeholder_pv_channels = data_module.find_placeholder_pv_channels
 get_allowed_battery_modes = data_module.get_allowed_battery_modes
 get_battery_flow_direction = data_module.get_battery_flow_direction
 get_schedule_modes = data_module.get_schedule_modes
+get_microinverter_port_count = data_module.get_microinverter_port_count
 get_signed_battery_power = data_module.get_signed_battery_power
 is_battery_charging = data_module.is_battery_charging
 latest_module_values = data_module.latest_module_values
 merge_missing_pv_channel_values = data_module.merge_missing_pv_channel_values
 relay_settings_enabled = data_module.relay_settings_enabled
+seed_missing_pv_channels = data_module.seed_missing_pv_channels
 validate_schedule_draft = data_module.validate_schedule_draft
 
 
@@ -264,6 +267,126 @@ def test_find_placeholder_pv_channels_ignores_channels_with_real_values() -> Non
     }
 
     assert find_placeholder_pv_channels(pv_indicators) == []
+
+
+# --- Port-count derived channels (issue #39) ---------------------------------
+
+# An HMS-800-2WB reported by the issue: two physical ports, but the indicators
+# feed only ever returns keys for channel 1.
+HMS_800_2WB = {
+    "33820520": {
+        "id": 33820520,
+        "init_hard_no": "HMS-800-2WB",
+        "rule": {"dev_type": 3, "port": 2},
+    }
+}
+ONE_CHANNEL_FEED = {
+    "pv_total": 1,
+    "list": [
+        {"key": "pv_p_total", "val": 26.1},
+        {"key": "1_pv_v", "val": 32.7},
+        {"key": "1_pv_i", "val": 0.8},
+        {"key": "1_pv_p", "val": 26.1},
+    ],
+}
+
+
+def test_get_microinverter_port_count_reads_rule_port() -> None:
+    """The port count comes from rule.port in the detail payload."""
+    assert get_microinverter_port_count(HMS_800_2WB["33820520"]) == 2
+    assert get_microinverter_port_count({"rule": {"port": "4"}}) == 4
+
+
+@pytest.mark.parametrize(
+    "micro",
+    [
+        None,
+        {},
+        {"rule": None},
+        {"rule": {}},
+        {"rule": {"port": 0}},
+        {"rule": {"port": -1}},
+        {"rule": {"port": "two"}},
+        {"rule": {"port": True}},
+    ],
+)
+def test_get_microinverter_port_count_rejects_unusable_values(micro) -> None:
+    """Anything that is not a positive integer port count yields None."""
+    assert get_microinverter_port_count(micro) is None
+
+
+def test_expected_pv_channels_from_single_microinverter() -> None:
+    """A single two-port microinverter implies channels 1 and 2."""
+    assert expected_pv_channels(HMS_800_2WB) == [1, 2]
+
+
+def test_expected_pv_channels_declines_multi_microinverter_stations() -> None:
+    """Channel-to-port mapping is unknown with several devices (#56)."""
+    microinverters = {
+        "1": {"rule": {"port": 2}},
+        "2": {"rule": {"port": 2}},
+    }
+
+    assert expected_pv_channels(microinverters) == []
+
+
+def test_expected_pv_channels_without_port_count() -> None:
+    """A detail payload that states no port count claims nothing."""
+    assert expected_pv_channels({"1": {}}) == []
+    assert expected_pv_channels({}) == []
+    assert expected_pv_channels(None) == []
+
+
+def test_seed_missing_pv_channels_adds_the_omitted_channel() -> None:
+    """The channel the feed never reports becomes a fillable placeholder."""
+    seeded = seed_missing_pv_channels(ONE_CHANNEL_FEED, HMS_800_2WB)
+
+    assert discover_pv_channels(seeded) == [1, 2]
+    # Channel 1 keeps its real values; only channel 2 is a placeholder.
+    assert find_placeholder_pv_channels(seeded) == [2]
+
+
+def test_seed_missing_pv_channels_does_not_mutate_the_feed() -> None:
+    """Seeding returns a copy, leaving the fetched payload untouched."""
+    seed_missing_pv_channels(ONE_CHANNEL_FEED, HMS_800_2WB)
+
+    assert discover_pv_channels(ONE_CHANNEL_FEED) == [1]
+
+
+def test_seed_missing_pv_channels_is_a_noop_when_the_feed_is_complete() -> None:
+    """A feed already reporting every port is returned unchanged."""
+    feed = {
+        "list": [
+            {"key": "1_pv_p", "val": 26.1},
+            {"key": "2_pv_p", "val": 30.4},
+        ]
+    }
+
+    assert seed_missing_pv_channels(feed, HMS_800_2WB) is feed
+
+
+def test_seed_missing_pv_channels_ignores_an_empty_feed() -> None:
+    """A failed indicators fetch must not invent channels."""
+    assert seed_missing_pv_channels({}, HMS_800_2WB) == {}
+    assert seed_missing_pv_channels(None, HMS_800_2WB) == {}
+    assert seed_missing_pv_channels({"list": []}, HMS_800_2WB) == {"list": []}
+
+
+def test_seeded_channel_is_filled_by_module_data() -> None:
+    """End to end: an omitted channel is seeded and then filled (#39)."""
+    seeded = seed_missing_pv_channels(ONE_CHANNEL_FEED, HMS_800_2WB)
+
+    merged = merge_missing_pv_channel_values(
+        seeded,
+        {2: {"MODULE_V": 33.1, "MODULE_I": 0.9, "MODULE_POWER": 29.8}},
+    )
+
+    values = {item["key"]: item["val"] for item in merged["list"]}
+    assert values["2_pv_v"] == 33.1
+    assert values["2_pv_i"] == 0.9
+    assert values["2_pv_p"] == 29.8
+    # Channel 1's real readings are left alone.
+    assert values["1_pv_p"] == 26.1
 
 
 def test_merge_replaces_placeholder_channel_values() -> None:


### PR DESCRIPTION
Fixes #39. Solves part A of #56.

## Problem

The module-data fallback added in #48 only fills channels the PV indicators feed **already advertises**. Both `discover_pv_channels` and `find_placeholder_pv_channels` read exclusively from that feed, so on a station whose firmware omits a channel entirely there is nothing to discover and nothing to fill — the fallback never runs and the PV2 entities are never created.

@jonandel posted the diagnostics on #39 that pin this down, and they are exactly what #56 asked for:

```json
"microinverters": {
  "33820520": { "init_hard_no": "HMS-800-2WB", "rule": { "dev_type": 3, "port": 2 } }
},
"pv_indicators": {
  "pv_total": 1,
  "list": [
    { "key": "pv_p_total", "val": 26.1 },
    { "key": "1_pv_v", "val": 32.7 },
    { "key": "1_pv_i", "val": 0.8 },
    { "key": "1_pv_p", "val": 26.1 }
  ]
},
"capabilities": { "pv_channels": [1] }
```

Two ports in hardware, one channel in the feed. Note `pv_total` is `1` — it agrees with the truncated feed rather than with the hardware, so it is not usable either.

## Change

`rule.port` in the microinverter detail payload is the authoritative port count, and it is per-device, matching the `port` the module-data endpoint takes.

- **`get_microinverter_port_count()`** — reads `rule.port`, rejecting anything that is not a positive integer (including `True`, which `isinstance(x, int)` would otherwise accept).
- **`expected_pv_channels()`** — returns `1..port` for a single-microinverter station. Returns `[]` for a multi-microinverter station: `channel N == port N` is only sound with one device, and the station-level mapping is still unknown.
- **`seed_missing_pv_channels()`** — inserts placeholder `v`/`i`/`p` entries for channels the feed omits. That turns "channel absent" into "channel present but unset", which is precisely the state `find_placeholder_pv_channels` already looks for, so the existing fallback fills it with no changes of its own. An empty feed means the fetch failed rather than that channels are missing, so it is left untouched.
- **`capabilities.expected_pv_channels` and `microinverter_port_counts`** — so a diagnostics export shows what was derived and from which field, rather than only the end result.

Entity creation needed no change: `sensor.py` already builds entities per `discover_pv_channels`, which now sees the seeded channel.

## What this deliberately does not do

Multi-microinverter stations behave exactly as before. Solving them needs the real channel-to-port mapping, which nothing we fetch states — guessing it is the failure mode #53 introduced and had to revert. Part B of #56 stays open.

A seeded channel that the module-data endpoint cannot fill stays unset and reads as unknown. Visibly missing, not silently borrowing channel 1's value.

## Validation

`pytest -q` — 101 passed, 11 new: `rule.port` parsing and its rejection cases, single- vs multi-microinverter derivation, seeding (including no-op and empty-feed paths), non-mutation of the fetched payload, and an end-to-end case running @jonandel's payload through seed → probe → merge.

Not yet confirmed against the reporter's own station — the derivation is exercised against their posted payload, but whether the module-data endpoint actually returns a series for port 2 on that hardware can only be established on the station itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)