### PR TITLE
Release 1.3.1: promote RC3 telemetry and reliability fixes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,3 +43,16 @@ jobs:
         # The suite deliberately runs without Home Assistant installed; see
         # tests/module_loader.py and AGENTS.md.
         run: pytest -q
+
+  homeassistant-smoke:
+    name: Home Assistant lifecycle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - name: Install tested Home Assistant runtime
+        run: python -m pip install homeassistant==2026.9.2 argon2-cffi
+      - name: Validate lifecycle with fake cloud transport
+        run: python scripts/validate_homeassistant.py

--- a/README.md
+++ b/README.md
@@ -2,6 +2,29 @@
 
 This custom integration for Home Assistant allows you to monitor and control your Hoymiles solar inverter system through the Hoymiles Cloud API.
 
+## Release candidate: 1.3.1rc1
+
+This prerelease targets **1.3.1** and builds on 1.3.0. It includes Claude's
+single-microinverter port-count discovery work and further telemetry, privacy,
+and lifecycle fixes. See [candidate notes](docs/release-1.3.1rc1.md).
+
+- EV charger power now uses the portal's signed live burst endpoint. The old
+  `pile_power` field can mirror solar output and is no longer used as charger
+  telemetry. An unavailable stream produces an unavailable sensor, not a made-up
+  zero. A fresh live zero remains zero when the station advertises a charger.
+- Optional entities can appear after setup as device data becomes available.
+- Battery commands must pass a settings read and readback verification; an
+  unconfirmed write is reported as a failure.
+- Each configured account has separate draft storage. Existing drafts are copied
+  from legacy storage automatically, without deleting the legacy file.
+- Reauthentication updates the same account. Diagnostics redact the account title
+  and signed URLs as well as credentials and identifiers.
+
+Install the prerelease only if you want to test these changes. For manual
+installation, extract the release archive's `custom_components/hoymiles_cloud`
+folder into your Home Assistant configuration and restart Home Assistant.
+Preserve a configuration backup if you need to roll back draft edits.
+
 ## Features
 
 - **Data Monitoring:**
@@ -14,7 +37,7 @@ This custom integration for Home Assistant allows you to monitor and control you
   - Dynamic PV channel discovery based on the indicators returned by the account
   - Per-channel PV voltage/current/power values via the module-data endpoint when the indicators feed only returns placeholders
   - Reported inverter count and battery settings access diagnostics
-  
+
 - **Control Functions:**
   - Set battery operation mode when the account exposes writable battery settings
   - Configure battery reserve state of charge for the modes returned by the account
@@ -102,6 +125,16 @@ After configuration, the integration will create:
 The integration creates PV input sensors from the indicator keys returned by the API. If a system has more than two PV inputs and Hoymiles exposes them in the indicators payload, matching Home Assistant sensors will be created automatically.
 
 The sensors will update every minute by default, but this can be changed in the integration options.
+
+Inventory and battery/relay settings are refreshed less frequently (normally
+every five minutes); a successful control write invalidates the settings cache.
+The live stream is polled at the configured integration interval. Cloud data can still be older than the polling
+interval. No existing historical statistics are rewritten.
+
+Live burst support currently validates the observed EU host (`eurt.hoymiles.com`).
+Other regions may retain aggregate telemetry while the charger sensor remains
+unavailable. Multi-microinverter channel-to-port mappings and per-device
+temperatures remain unsupported where the cloud payload has not been verified.
 
 ### Schedule editor
 
@@ -207,4 +240,4 @@ For bugs or feature requests, please [open an issue on GitHub](https://github.co
 
 ## Disclaimer
 
-This integration is not affiliated with, endorsed by, or connected to Hoymiles Power Electronics Inc. This is a third-party integration developed for personal use. 
+This integration is not affiliated with, endorsed by, or connected to Hoymiles Power Electronics Inc. This is a third-party integration developed for personal use.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 
 This custom integration for Home Assistant allows you to monitor and control your Hoymiles solar inverter system through the Hoymiles Cloud API.
 
-## Release candidate: 1.3.1rc1
+## Release candidate: 1.3.1rc2
 
 This prerelease targets **1.3.1** and builds on 1.3.0. It includes Claude's
 single-microinverter port-count discovery work and further telemetry, privacy,
-and lifecycle fixes. See [candidate notes](docs/release-1.3.1rc1.md).
+and lifecycle fixes. See [candidate notes](docs/release-1.3.1rc2.md).
 
+- RC2 fixes the missing authorization header on burst requests, verified with
+  read-only live cloud samples. Polling still uses the configured integration
+  interval; dedicated fast PV polling is not included.
 - EV charger power now uses the portal's signed live burst endpoint. The old
   `pile_power` field can mirror solar output and is no longer used as charger
   telemetry. An unavailable stream produces an unavailable sensor, not a made-up

--- a/custom_components/hoymiles_cloud/__init__.py
+++ b/custom_components/hoymiles_cloud/__init__.py
@@ -46,6 +46,7 @@ from .data import (
     get_schedule_draft,
     merge_missing_pv_channel_values,
     remove_schedule_entry,
+    seed_missing_pv_channels,
     set_schedule_editor_selection,
     update_schedule_editor_draft,
 )
@@ -677,6 +678,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
                     microinverters = static_payload.get("devices", {}).get(
                         "microinverters", {}
+                    )
+                    # Channels the feed omits entirely are seeded from the
+                    # microinverter's own port count, so the fallback below can
+                    # fill them like any other placeholder (issue #39).
+                    pv_indicators = seed_missing_pv_channels(
+                        pv_indicators, microinverters
                     )
                     placeholder_channels = find_placeholder_pv_channels(pv_indicators)
                     if placeholder_channels and len(microinverters) == 1:

--- a/custom_components/hoymiles_cloud/__init__.py
+++ b/custom_components/hoymiles_cloud/__init__.py
@@ -1,11 +1,11 @@
 """The Hoymiles Cloud Integration."""
 from copy import deepcopy
+import asyncio
 import logging
 from datetime import timedelta
 import time
 from typing import Any
 
-import async_timeout
 from homeassistant.config_entries import ConfigEntry, ConfigEntryAuthFailed
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -50,8 +50,9 @@ from .data import (
     set_schedule_editor_selection,
     update_schedule_editor_draft,
 )
-from .hoymiles_api import HoymilesAPI
+from .hoymiles_api import HoymilesAPI, LiveDataAuthError
 from .models import AIStatus, DeviceInventory, EPSProfit, EnergyFlow, FirmwareStatus, SettingRules, StationData
+from .storage import entry_storage_key, migrate_legacy_stations
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -211,6 +212,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         if not await runtime["api"].set_battery_mode(station_id, mode):
             raise HomeAssistantError("Failed to update the Hoymiles battery mode")
 
+        runtime["control_cache_at"].pop(station_id, None)
         await runtime["coordinator"].async_request_refresh()
 
     async def async_handle_set_battery_mode_settings(call: ServiceCall) -> None:
@@ -240,6 +242,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                 int(reserve_soc),
             )
 
+        runtime["control_cache_at"].pop(station_id, None)
         await runtime["coordinator"].async_request_refresh()
 
     async def async_handle_load_schedule_draft(call: ServiceCall) -> None:
@@ -473,8 +476,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     session = async_get_clientsession(hass)
     api = HoymilesAPI(session, username, password)
     api.configure_auth(auth_mode=auth_mode, app_version=app_version)
-    store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
-    stored_data = await store.async_load() or {}
+    store = Store(hass, STORAGE_VERSION, entry_storage_key(STORAGE_KEY, entry.entry_id))
+    stored_data = await store.async_load()
 
     try:
         auth_result = await api.authenticate()
@@ -496,6 +499,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not stations:
         raise ConfigEntryNotReady("No Hoymiles stations were returned for this account")
 
+    if stored_data is None:
+        legacy = await Store(hass, STORAGE_VERSION, STORAGE_KEY).async_load()
+        stored_data = migrate_legacy_stations(legacy, set(stations))
+        await store.async_save(stored_data)
+
     if _ensure_station_storage(stored_data, stations):
         await store.async_save(stored_data)
 
@@ -504,6 +512,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     module_data_cache: dict[tuple[str, int], dict[str, float | None]] = {}
     module_data_cache_at: dict[tuple[str, int], float] = {}
     module_data_failures: set[tuple[str, int]] = set()
+    request_limit = asyncio.Semaphore(4)
 
     async def _async_module_values(
         station_id: str,
@@ -562,271 +571,224 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return values_by_channel
 
     async def _async_fetch_static_station_payload(station_id: str) -> dict[str, Any]:
-        """Fetch slower-changing station metadata and device inventory."""
-        try:
-            station_info = await api.get_station_details(station_id)
-        except Exception as err:
-            _LOGGER.warning("Failed to get station details for station %s: %s", station_id, err)
-            station_info = {}
-        if station_info.get("name"):
-            stations[station_id] = str(station_info["name"])
-
-        try:
-            setting_rules = await api.get_setting_rules(station_id)
-        except Exception as err:
-            _LOGGER.warning("Failed to get setting rules for station %s: %s", station_id, err)
-            setting_rules = {}
-
-        try:
-            dtus = await api.get_dtus(station_id)
-        except Exception as err:
-            _LOGGER.warning("Failed to get DTUs for station %s: %s", station_id, err)
-            dtus = []
-
-        try:
-            inverters = await api.get_inverters(station_id)
-        except Exception as err:
-            _LOGGER.warning("Failed to get inverters for station %s: %s", station_id, err)
-            inverters = []
-
-        try:
-            batteries = await api.get_batteries(station_id)
-        except Exception as err:
-            _LOGGER.warning("Failed to get batteries for station %s: %s", station_id, err)
-            batteries = []
-
-        try:
-            meters = await api.get_meters(station_id)
-        except Exception as err:
-            _LOGGER.warning("Failed to get meters for station %s: %s", station_id, err)
-            meters = []
-
-        try:
-            microinverters = await api.get_microinverters_by_stations(station_id)
-        except Exception as err:
-            _LOGGER.warning("Failed to get microinverter details for station %s: %s", station_id, err)
-            microinverters = {}
-
-        try:
-            eps_settings = await api.get_eps_settings(station_id)
-        except Exception as err:
-            _LOGGER.warning("Failed to get EPS settings for station %s: %s", station_id, err)
-            eps_settings = {}
-
-        try:
-            ai_status = await api.get_ai_status(station_id)
-        except Exception as err:
-            _LOGGER.warning("Failed to get AI status for station %s: %s", station_id, err)
-            ai_status = {}
-
-        try:
-            firmware = await api.get_firmware_status(station_id)
-        except Exception as err:
-            _LOGGER.warning("Failed to get firmware status for station %s: %s", station_id, err)
-            firmware = {}
-
-        return {
-            "station_info": station_info,
-            "setting_rules": SettingRules(setting_rules).as_dict(),
-            "devices": DeviceInventory(
-                dtus=dtus,
-                inverters=inverters,
-                batteries=batteries,
-                meters=meters,
-                microinverters=microinverters,
-            ).as_dict(),
-            "eps_settings": eps_settings,
-            "ai_status": AIStatus(ai_status).as_dict(),
-            "firmware": FirmwareStatus(firmware).as_dict(),
+        """Refresh inventory independently of the live telemetry deadline."""
+        methods = {
+            "station_info": api.get_station_details,
+            "setting_rules": api.get_setting_rules,
+            "dtus": api.get_dtus,
+            "inverters": api.get_inverters,
+            "batteries": api.get_batteries,
+            "meters": api.get_meters,
+            "microinverters": api.get_microinverters_by_stations,
+            "eps_settings": api.get_eps_settings,
+            "ai_status": api.get_ai_status,
+            "firmware": api.get_firmware_status,
         }
 
-    async def async_update_data():
-        """Fetch data from API."""
+        async def fetch(name: str, method: Any) -> tuple[str, Any]:
+            try:
+                async with request_limit:
+                    return name, await asyncio.wait_for(method(station_id), timeout=8)
+            except LiveDataAuthError:
+                raise
+            except Exception as err:
+                _LOGGER.debug("Static %s read failed for station %s: %s", name, station_id, err)
+                return name, None
+
+        results = dict(await asyncio.gather(*(fetch(name, method) for name, method in methods.items())))
+        previous = static_station_cache.get(station_id, {})
+        station_info = results["station_info"] or previous.get("station_info", {})
+        if station_info.get("name"):
+            stations[station_id] = str(station_info["name"])
+        old_devices = previous.get("devices", {})
+        devices = DeviceInventory(
+            dtus=results["dtus"] if results["dtus"] is not None else old_devices.get("dtus", []),
+            inverters=results["inverters"] if results["inverters"] is not None else old_devices.get("inverters", []),
+            batteries=results["batteries"] if results["batteries"] is not None else old_devices.get("batteries", []),
+            meters=results["meters"] if results["meters"] is not None else old_devices.get("meters", []),
+            microinverters=results["microinverters"] if results["microinverters"] is not None else old_devices.get("microinverters", {}),
+        ).as_dict()
+        def keep(name: str, wrapper: Any = None) -> dict[str, Any]:
+            value = results[name]
+            if value is None:
+                return previous.get(name, {})
+            return wrapper(value).as_dict() if wrapper else value
+        return {
+            "station_info": station_info,
+            "setting_rules": keep("setting_rules", SettingRules),
+            "devices": devices,
+            "eps_settings": keep("eps_settings"),
+            "ai_status": keep("ai_status", AIStatus),
+            "firmware": keep("firmware", FirmwareStatus),
+        }
+
+    station_limit = asyncio.Semaphore(3)
+    optional_failures: set[tuple[str, str]] = set()
+    control_cache: dict[str, dict[str, Any]] = {}
+    control_cache_at: dict[str, float] = {}
+
+    async def _optional(station_id: str, name: str, method: Any, timeout: float = 6) -> Any:
+        """A failed optional endpoint cannot fail station telemetry."""
         try:
-            async with async_timeout.timeout(30):
-                if api.is_token_expired() and not await api.authenticate():
-                    raise ConfigEntryAuthFailed(
-                        "Hoymiles authentication failed: "
-                        f"{api.last_auth_status} - {api.last_auth_message} "
-                        f"({api.last_auth_attempt_summary})"
-                    )
-
-                refreshed: dict[str, dict] = {}
-                should_save_store = False
-
-                for station_id in stations:
-                    now = time.monotonic()
-                    if (
-                        station_id not in static_station_cache
-                        or now - static_station_cache_at.get(station_id, 0) >= DEFAULT_STATIC_REFRESH_INTERVAL
-                    ):
-                        static_station_cache[station_id] = await _async_fetch_static_station_payload(station_id)
-                        static_station_cache_at[station_id] = now
-                    static_payload = static_station_cache.get(station_id, {})
-
-                    real_time_data = await api.get_real_time_data(station_id)
-
-                    try:
-                        pv_indicators = await api.get_pv_indicators(station_id)
-                    except Exception as err:
-                        _LOGGER.warning(
-                            "Failed to get PV indicators for station %s: %s",
-                            station_id,
-                            err,
-                        )
-                        pv_indicators = {}
-
-                    microinverters = static_payload.get("devices", {}).get(
-                        "microinverters", {}
-                    )
-                    # Channels the feed omits entirely are seeded from the
-                    # microinverter's own port count, so the fallback below can
-                    # fill them like any other placeholder (issue #39).
-                    pv_indicators = seed_missing_pv_channels(
-                        pv_indicators, microinverters
-                    )
-                    placeholder_channels = find_placeholder_pv_channels(pv_indicators)
-                    if placeholder_channels and len(microinverters) == 1:
-                        micro = next(iter(microinverters.values()))
-                        mi_id = micro.get("id") if isinstance(micro, dict) else None
-                        if mi_id is not None:
-                            module_values_by_channel = await _async_module_values(
-                                station_id, mi_id, placeholder_channels
-                            )
-                            if module_values_by_channel:
-                                pv_indicators = merge_missing_pv_channel_values(
-                                    pv_indicators, module_values_by_channel
-                                )
-                    elif placeholder_channels:
-                        _LOGGER.debug(
-                            "Skipping module data fallback for station %s: "
-                            "%s microinverters",
-                            station_id,
-                            len(microinverters),
-                        )
-
-                    if fetch_grid_indicators:
-                        try:
-                            grid_indicators = await api.get_grid_indicators(station_id)
-                        except Exception as err:
-                            _LOGGER.warning(
-                                "Failed to get grid indicators for station %s: %s",
-                                station_id,
-                                err,
-                            )
-                            grid_indicators = {}
-                    else:
-                        grid_indicators = {}
-
-                    try:
-                        load_indicators = await api.get_load_indicators(station_id)
-                    except Exception as err:
-                        _LOGGER.warning(
-                            "Failed to get load indicators for station %s: %s",
-                            station_id,
-                            err,
-                        )
-                        load_indicators = {}
-
-                    try:
-                        battery_settings = await api.get_battery_settings(station_id)
-                    except Exception as err:
-                        _LOGGER.warning(
-                            "Failed to get battery settings for station %s: %s",
-                            station_id,
-                            err,
-                        )
-                        battery_settings = {}
-
-                    try:
-                        relay_settings = await api.get_relay_settings(station_id)
-                    except Exception as err:
-                        _LOGGER.warning(
-                            "Failed to get relay settings for station %s: %s",
-                            station_id,
-                            err,
-                        )
-                        relay_settings = {}
-
-                    if fetch_energy_flow:
-                        try:
-                            energy_flow = await api.get_energy_flow(station_id)
-                        except Exception as err:
-                            _LOGGER.warning(
-                                "Failed to get energy flow for station %s: %s",
-                                station_id,
-                                err,
-                            )
-                            energy_flow = {}
-                    else:
-                        energy_flow = {}
-
-                    if fetch_eps_profit:
-                        try:
-                            eps_profit = await api.get_eps_profit(station_id)
-                        except Exception as err:
-                            _LOGGER.warning(
-                                "Failed to get EPS profit for station %s: %s",
-                                station_id,
-                                err,
-                            )
-                            eps_profit = {}
-                    else:
-                        eps_profit = {}
-
-                    station_stored_data = stored_data["stations"].setdefault(station_id, {})
-                    enhanced_battery_settings, station_changed = _enhance_battery_settings(
-                        battery_settings,
-                        station_stored_data,
-                    )
-                    should_save_store = should_save_store or station_changed
-
-                    refreshed[station_id] = StationData(
-                        station_info=static_payload.get("station_info", {}),
-                        real_time_data=real_time_data,
-                        energy_flow=EnergyFlow(energy_flow).as_dict(),
-                        pv_indicators=pv_indicators,
-                        grid_indicators=grid_indicators,
-                        load_indicators=load_indicators,
-                        battery_settings=enhanced_battery_settings,
-                        relay_settings=relay_settings,
-                        eps_settings=static_payload.get("eps_settings", {}),
-                        eps_profit=EPSProfit(eps_profit).as_dict(),
-                        ai_status=static_payload.get("ai_status", {}),
-                        setting_rules=static_payload.get("setting_rules", {}),
-                        devices=static_payload.get("devices", {}),
-                        firmware=static_payload.get("firmware", {}),
-                        schedule_editor=build_schedule_editor_state(
-                            enhanced_battery_settings,
-                            station_stored_data,
-                        ),
-                        capabilities=build_station_capabilities(
-                            real_time_data=real_time_data,
-                            pv_indicators=pv_indicators,
-                            battery_settings=enhanced_battery_settings,
-                            microinverters_data=static_payload.get("devices", {}).get("microinverters", {}),
-                            grid_indicators=grid_indicators,
-                            load_indicators=load_indicators,
-                            energy_flow=energy_flow,
-                            relay_settings=relay_settings,
-                            setting_rules=static_payload.get("setting_rules", {}),
-                            devices=static_payload.get("devices", {}),
-                            eps_settings=static_payload.get("eps_settings", {}),
-                            eps_profit=eps_profit,
-                            ai_status=static_payload.get("ai_status", {}),
-                            firmware=static_payload.get("firmware", {}),
-                            station_info=static_payload.get("station_info", {}),
-                        ),
-                    ).as_dict()
-
-                if should_save_store:
-                    await store.async_save(stored_data)
-
-                return refreshed
-        except ConfigEntryAuthFailed:
+            async with request_limit:
+                result = await asyncio.wait_for(method(station_id), timeout=timeout)
+        except LiveDataAuthError:
             raise
         except Exception as err:
-            raise UpdateFailed(f"Error updating data: {err}") from err
+            key = (station_id, name)
+            log = _LOGGER.debug if key in optional_failures else _LOGGER.warning
+            log("Failed to get %s for station %s: %s", name, station_id, err)
+            optional_failures.add(key)
+            return None
+        optional_failures.discard((station_id, name))
+        return result
+
+    async def _station_update(station_id: str) -> tuple[str, dict[str, Any], bool]:
+        async with station_limit:
+            now = time.monotonic()
+            if (station_id not in static_station_cache or
+                    now - static_station_cache_at.get(station_id, 0) >= DEFAULT_STATIC_REFRESH_INTERVAL):
+                static_station_cache[station_id] = await _async_fetch_static_station_payload(station_id)
+                static_station_cache_at[station_id] = now
+            static_payload = static_station_cache.get(station_id, {})
+
+            names = ["real_time_data", "live_data", "pv_indicators", "load_indicators"]
+            methods = [api.get_real_time_data, api.get_live_data, api.get_pv_indicators, api.get_load_indicators]
+            if fetch_grid_indicators:
+                names.append("grid_indicators")
+                methods.append(api.get_grid_indicators)
+            if fetch_energy_flow:
+                names.append("energy_flow")
+                methods.append(api.get_energy_flow)
+            if fetch_eps_profit:
+                names.append("eps_profit")
+                methods.append(api.get_eps_profit)
+            values = await asyncio.gather(*(
+                _optional(station_id, name, method, 45 if name == "live_data" else 6)
+                for name, method in zip(names, methods)
+            ))
+            payloads = dict(zip(names, values))
+            real_time_data = payloads.get("real_time_data") or {}
+            live_data = payloads.get("live_data") or {}
+            live_fetched_at = time.time() if live_data else None
+            pv_indicators = payloads.get("pv_indicators") or {}
+            microinverters = static_payload.get("devices", {}).get("microinverters", {})
+            pv_indicators = seed_missing_pv_channels(pv_indicators, microinverters)
+            placeholders = find_placeholder_pv_channels(pv_indicators)
+            if placeholders and len(microinverters) == 1:
+                micro = next(iter(microinverters.values()))
+                mi_id = micro.get("id") if isinstance(micro, dict) else None
+                if mi_id is not None:
+                    try:
+                        module_values = await asyncio.wait_for(
+                            _async_module_values(station_id, mi_id, placeholders), timeout=5
+                        )
+                    except asyncio.TimeoutError:
+                        module_values = {}
+                    if module_values:
+                        pv_indicators = merge_missing_pv_channel_values(pv_indicators, module_values)
+
+            if (station_id not in control_cache or
+                    now - control_cache_at.get(station_id, 0) >= DEFAULT_STATIC_REFRESH_INTERVAL):
+                battery, relay = await asyncio.gather(
+                    _optional(station_id, "battery_settings", api.get_battery_settings, 12),
+                    _optional(station_id, "relay_settings", api.get_relay_settings, 8),
+                )
+                control_cache[station_id] = {
+                    "battery_settings": battery or {},
+                    "relay_settings": relay or {},
+                }
+                control_cache_at[station_id] = now
+            control = control_cache[station_id]
+            battery_settings = control["battery_settings"]
+            relay_settings = control["relay_settings"]
+            grid_indicators = payloads.get("grid_indicators") or {}
+            load_indicators = payloads.get("load_indicators") or {}
+            energy_flow = payloads.get("energy_flow") or {}
+            eps_profit = payloads.get("eps_profit") or {}
+            station_stored_data = stored_data["stations"].setdefault(station_id, {})
+            enhanced_battery_settings, changed = _enhance_battery_settings(
+                battery_settings, station_stored_data
+            )
+            result = StationData(
+                station_info=static_payload.get("station_info", {}),
+                real_time_data=real_time_data,
+                live_data=live_data,
+                live_fetched_at=live_fetched_at,
+                live_max_age=max(90, scan_interval * 2),
+                telemetry_available=bool(real_time_data or live_data),
+                energy_flow=EnergyFlow(energy_flow).as_dict(),
+                pv_indicators=pv_indicators,
+                grid_indicators=grid_indicators,
+                load_indicators=load_indicators,
+                battery_settings=enhanced_battery_settings,
+                relay_settings=relay_settings,
+                eps_settings=static_payload.get("eps_settings", {}),
+                eps_profit=EPSProfit(eps_profit).as_dict(),
+                ai_status=static_payload.get("ai_status", {}),
+                setting_rules=static_payload.get("setting_rules", {}),
+                devices=static_payload.get("devices", {}),
+                firmware=static_payload.get("firmware", {}),
+                schedule_editor=build_schedule_editor_state(enhanced_battery_settings, station_stored_data),
+                capabilities=build_station_capabilities(
+                    real_time_data=real_time_data,
+                    pv_indicators=pv_indicators,
+                    battery_settings=enhanced_battery_settings,
+                    microinverters_data=microinverters,
+                    grid_indicators=grid_indicators,
+                    load_indicators=load_indicators,
+                    energy_flow=energy_flow,
+                    relay_settings=relay_settings,
+                    setting_rules=static_payload.get("setting_rules", {}),
+                    devices=static_payload.get("devices", {}),
+                    eps_settings=static_payload.get("eps_settings", {}),
+                    eps_profit=eps_profit,
+                    ai_status=static_payload.get("ai_status", {}),
+                    firmware=static_payload.get("firmware", {}),
+                    station_info=static_payload.get("station_info", {}),
+                ),
+            ).as_dict()
+            return station_id, result, changed
+
+    async def async_update_data():
+        """Refresh stations independently and keep failed stations unavailable."""
+        if api.is_token_expired() and not await api.authenticate():
+            raise ConfigEntryAuthFailed(
+                "Hoymiles authentication failed: "
+                f"{api.last_auth_status} - {api.last_auth_message}"
+            )
+        results = await asyncio.gather(
+            *(_station_update(station_id) for station_id in stations),
+            return_exceptions=True,
+        )
+        refreshed: dict[str, dict[str, Any]] = {}
+        should_save = False
+        for station_id, result in zip(stations, results):
+            if isinstance(result, LiveDataAuthError):
+                raise ConfigEntryAuthFailed("Hoymiles Cloud session is no longer authorized") from result
+            if isinstance(result, BaseException):
+                _LOGGER.warning("Station %s refresh failed: %s", station_id, result)
+                previous = (coordinator.data or {}).get(station_id, {})
+                refreshed[station_id] = {
+                    **previous,
+                    "real_time_data": {},
+                    "live_data": {},
+                    "live_fetched_at": None,
+                    "telemetry_available": False,
+                    "pv_indicators": {},
+                    "grid_indicators": {},
+                    "load_indicators": {},
+                    "energy_flow": {},
+                    "eps_profit": {},
+                }
+            else:
+                _, refreshed[station_id], changed = result
+                should_save = should_save or changed
+        if should_save:
+            await store.async_save(stored_data)
+        if not any(item.get("telemetry_available") for item in refreshed.values()):
+            raise UpdateFailed("No station telemetry could be refreshed")
+        return refreshed
 
     coordinator = DataUpdateCoordinator(
         hass,
@@ -847,6 +809,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "stored_data": stored_data,
         "entry": entry,
         "static_station_cache": static_station_cache,
+        "control_cache_at": control_cache_at,
+        "invalidate_control_cache": lambda station_id: control_cache_at.pop(station_id, None),
         "fetch_grid_indicators": fetch_grid_indicators,
         "fetch_energy_flow": fetch_energy_flow,
         "fetch_eps_profit": fetch_eps_profit,
@@ -950,8 +914,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if not await api.set_battery_mode_settings(station_id, mode, payload, merge=True):
             raise HomeAssistantError("Failed to apply the Hoymiles schedule draft")
 
+        control_cache_at.pop(station_id, None)
+        await coordinator.async_refresh()
+        if not coordinator.last_update_success or not battery_settings_readable(
+            (coordinator.data or {}).get(station_id, {}).get("battery_settings", {})
+        ):
+            raise HomeAssistantError(
+                "Schedule write completed, but fresh settings could not be read; the draft was retained"
+            )
         await async_load_schedule_draft(station_id, mode)
-        await coordinator.async_request_refresh()
 
     async def async_add_schedule_entry_for_mode(station_id: str, mode: int) -> None:
         """Add a new schedule row or date window for the selected editor mode."""
@@ -978,7 +949,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await _async_register_services(hass)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_on_unload(entry.add_update_listener(update_listener))
+    original_options = dict(entry.options)
+
+    async def options_update_listener(hass: HomeAssistant, updated_entry: ConfigEntry) -> None:
+        """Only options require listener reload; reauth performs its own reload."""
+        if dict(updated_entry.options) != original_options:
+            await hass.config_entries.async_reload(updated_entry.entry_id)
+
+    entry.async_on_unload(entry.add_update_listener(options_update_listener))
     return True
 
 
@@ -989,8 +967,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id, None)
         await _async_unregister_services(hass)
     return unload_ok
-
-
-async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Handle options update."""
-    await hass.config_entries.async_reload(entry.entry_id) 

--- a/custom_components/hoymiles_cloud/binary_sensor.py
+++ b/custom_components/hoymiles_cloud/binary_sensor.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+# Coordinator polls and API writes manage their own scheduling.
+PARALLEL_UPDATES = 0
+
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -16,8 +19,9 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
+from .discovery import register_discovery
 from .const import DOMAIN
-from .data import is_battery_charging
+from .data import get_grid_connected, is_battery_charging
 from .device import build_primary_battery_device_info, build_station_device_info
 
 
@@ -53,7 +57,7 @@ DESCRIPTIONS: list[HoymilesBinarySensorDescription] = [
         key="grid_connected",
         name="Grid Connected",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
-        value_fn=lambda data: bool(get_reflux_data(data)),
+        value_fn=get_grid_connected,
         exists_fn=lambda data: True,
         device_info_fn=lambda sid, name, data: build_station_device_info(sid, name, data.get("station_info")),
     ),
@@ -87,22 +91,25 @@ async def async_setup_entry(
     coordinator = runtime_data["coordinator"]
     stations = runtime_data["stations"]
 
-    entities: list[BinarySensorEntity] = []
-    for station_id, station_name in stations.items():
-        station_data = get_station_data(coordinator, station_id)
-        for description in DESCRIPTIONS:
-            if description.exists_fn and not description.exists_fn(station_data):
-                continue
-            entities.append(
-                HoymilesBinarySensor(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    description,
+    def build_entities() -> list:
+        entities: list[BinarySensorEntity] = []
+        for station_id, station_name in stations.items():
+            station_data = get_station_data(coordinator, station_id)
+            for description in DESCRIPTIONS:
+                if description.exists_fn and not description.exists_fn(station_data):
+                    continue
+                entities.append(
+                    HoymilesBinarySensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        description,
+                    )
                 )
-            )
 
-    async_add_entities(entities)
+        return entities
+
+    register_discovery(coordinator, entry, async_add_entities, build_entities)
 
 
 class HoymilesBinarySensor(CoordinatorEntity, BinarySensorEntity):
@@ -144,6 +151,11 @@ class HoymilesBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def available(self) -> bool:
         """Return whether the entity is available."""
         if not self.coordinator.last_update_success:
+            return False
+        if (
+            self.entity_description.key in {"battery_charging", "grid_connected"}
+            and self._get_station_data().get("telemetry_available") is False
+        ):
             return False
         if self.entity_description.exists_fn:
             return self.entity_description.exists_fn(self._get_station_data())

--- a/custom_components/hoymiles_cloud/button.py
+++ b/custom_components/hoymiles_cloud/button.py
@@ -1,6 +1,9 @@
 """Button entities for the Hoymiles schedule editor."""
 from __future__ import annotations
 
+# Coordinator polls and API writes manage their own scheduling.
+PARALLEL_UPDATES = 0
+
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -8,6 +11,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
+from .discovery import register_discovery
 from .const import DOMAIN
 from .schedule_editor import build_device_info, get_selected_editor_mode, get_station_data
 
@@ -22,57 +26,60 @@ async def async_setup_entry(
     coordinator = runtime_data["coordinator"]
     stations = runtime_data["stations"]
 
-    entities = []
-    for station_id, station_name in stations.items():
-        station_data = coordinator.data.get(station_id, {}) if coordinator.data else {}
-        if not station_data.get("schedule_editor", {}).get("available_modes"):
-            continue
-        entities.extend(
-            [
-                HoymilesScheduleButton(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    runtime_data["load_schedule_draft"],
-                    "load_schedule_draft",
-                    "Load Live Schedule Draft",
-                ),
-                HoymilesScheduleButton(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    runtime_data["apply_schedule_draft"],
-                    "apply_schedule_draft",
-                    "Apply Schedule Draft",
-                ),
-                HoymilesScheduleButton(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    runtime_data["reset_schedule_draft"],
-                    "reset_schedule_draft",
-                    "Discard Schedule Draft",
-                ),
-                HoymilesScheduleButton(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    runtime_data["add_schedule_entry"],
-                    "add_schedule_entry",
-                    "Add Schedule Entry",
-                ),
-                HoymilesScheduleButton(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    runtime_data["remove_schedule_entry"],
-                    "remove_schedule_entry",
-                    "Remove Schedule Entry",
-                ),
-            ]
-        )
+    def build_entities() -> list:
+        entities = []
+        for station_id, station_name in stations.items():
+            station_data = coordinator.data.get(station_id, {}) if coordinator.data else {}
+            if not station_data.get("schedule_editor", {}).get("available_modes"):
+                continue
+            entities.extend(
+                [
+                    HoymilesScheduleButton(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        runtime_data["load_schedule_draft"],
+                        "load_schedule_draft",
+                        "Load Live Schedule Draft",
+                    ),
+                    HoymilesScheduleButton(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        runtime_data["apply_schedule_draft"],
+                        "apply_schedule_draft",
+                        "Apply Schedule Draft",
+                    ),
+                    HoymilesScheduleButton(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        runtime_data["reset_schedule_draft"],
+                        "reset_schedule_draft",
+                        "Discard Schedule Draft",
+                    ),
+                    HoymilesScheduleButton(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        runtime_data["add_schedule_entry"],
+                        "add_schedule_entry",
+                        "Add Schedule Entry",
+                    ),
+                    HoymilesScheduleButton(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        runtime_data["remove_schedule_entry"],
+                        "remove_schedule_entry",
+                        "Remove Schedule Entry",
+                    ),
+                ]
+            )
 
-    async_add_entities(entities)
+        return entities
+
+    register_discovery(coordinator, entry, async_add_entities, build_entities)
 
 
 class HoymilesScheduleButton(CoordinatorEntity, ButtonEntity):

--- a/custom_components/hoymiles_cloud/config_flow.py
+++ b/custom_components/hoymiles_cloud/config_flow.py
@@ -160,6 +160,71 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> FlowResult:
+        """Prompt for replacement credentials for an existing account."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Validate the new credentials before updating the existing entry."""
+        entry = self._reauth_entry
+        if entry is None:
+            return self.async_abort(reason="unknown")
+        errors: dict[str, str] = {}
+        defaults = {CONF_USERNAME: entry.data[CONF_USERNAME], CONF_PASSWORD: "",
+                    CONF_AUTH_MODE: entry.data.get(CONF_AUTH_MODE, AUTH_MODE_AUTO),
+                    CONF_APP_VERSION: entry.data.get(CONF_APP_VERSION, "")}
+        if user_input is not None:
+            username = user_input[CONF_USERNAME].strip()
+            if username.casefold() != entry.data[CONF_USERNAME].casefold():
+                errors["base"] = "account_mismatch"
+                return self.async_show_form(
+                    step_id="reauth_confirm",
+                    data_schema=_build_user_schema(user_input),
+                    errors=errors,
+                )
+            session = async_get_clientsession(self.hass)
+            api = HoymilesAPI(session, username, user_input[CONF_PASSWORD])
+            api.configure_auth(
+                auth_mode=user_input.get(CONF_AUTH_MODE, AUTH_MODE_AUTO),
+                app_version=user_input.get(CONF_APP_VERSION, "").strip() or None,
+            )
+            try:
+                authenticated = await api.authenticate()
+                if authenticated and not await api.get_stations():
+                    errors["base"] = AUTH_ERROR_NO_ACCESSIBLE_STATIONS
+                elif not authenticated:
+                    errors["base"] = auth_error_to_config_error(api.last_auth_error_key)
+            except Exception as err:
+                _LOGGER.debug("Reauthentication failed: %s", err)
+                errors["base"] = "cannot_connect"
+            if not errors:
+                for other in self.hass.config_entries.async_entries(DOMAIN):
+                    if other.entry_id != entry.entry_id and (
+                        other.unique_id or other.data.get(CONF_USERNAME, "")
+                    ).casefold() == username.casefold():
+                        errors["base"] = "already_configured"
+                        break
+            if not errors:
+                data = dict(entry.data)
+                data.update({CONF_USERNAME: username, CONF_PASSWORD: user_input[CONF_PASSWORD],
+                             CONF_AUTH_MODE: user_input.get(CONF_AUTH_MODE, AUTH_MODE_AUTO)})
+                app_version = user_input.get(CONF_APP_VERSION, "").strip()
+                if app_version:
+                    data[CONF_APP_VERSION] = app_version
+                else:
+                    data.pop(CONF_APP_VERSION, None)
+                self.hass.config_entries.async_update_entry(entry, data=data)
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=_build_user_schema(user_input or defaults),
+            errors=errors,
+        )
+
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for Hoymiles Cloud."""

--- a/custom_components/hoymiles_cloud/const.py
+++ b/custom_components/hoymiles_cloud/const.py
@@ -211,6 +211,12 @@ INDICATOR_FLOW_STAT_TYPE_GRID = 2
 INDICATOR_FLOW_STAT_TYPE_PV = 4
 INDICATOR_FLOW_STAT_TYPE_BATTERY = 10
 
+# Keys of the live reflux payload that advertise a charging pile (EV charger).
+# The vendor app renders the charging-pile node only when one of these icon
+# flags is set; ``pile_power`` itself is emitted even by stations that have no
+# charger at all, where it does not carry charger telemetry.
+EV_CHARGER_FLAG_KEYS = ("icon_plug", "icon_ai_plug")
+
 # Energy-flow stats types
 ENERGY_FLOW_STAT_TYPE_OVERVIEW = 1
 ENERGY_FLOW_STAT_TYPE_BATTERY = 4

--- a/custom_components/hoymiles_cloud/data.py
+++ b/custom_components/hoymiles_cloud/data.py
@@ -14,6 +14,7 @@ from .const import (
     BATTERY_MODE_IDS,
     BATTERY_MODE_TIME_OF_USE,
     BATTERY_SCHEDULE_MODE_IDS,
+    EV_CHARGER_FLAG_KEYS,
     INDICATOR_FLOW_STAT_TYPE_BATTERY,
     METER_LOCATION_NAMES,
     MODULE_DATA_MAX_AGE_MINUTES,
@@ -1074,6 +1075,56 @@ def is_battery_charging(station_data: dict[str, Any] | None) -> bool | None:
     return None
 
 
+def _ev_charger_flags(reflux_data: dict[str, Any]) -> list[Any]:
+    """Return the charging-pile icon flags the payload actually carries."""
+    return [reflux_data[key] for key in EV_CHARGER_FLAG_KEYS if key in reflux_data]
+
+
+def _flag_is_set(value: Any) -> bool:
+    """Return whether an API icon flag is set, tolerating string encodings."""
+    number = _optional_float(value)
+    if number is None:
+        return bool(value)
+    return number != 0
+
+
+def has_ev_charger(station_data: dict[str, Any] | None) -> bool:
+    """Return whether the station advertises a charging pile.
+
+    ``pile_power`` is present in the reflux payload of stations that have no EV
+    charger at all, where it does not carry charger telemetry (issue #64: it
+    mirrored PV power on a station with no vehicle connected). The vendor app
+    gates the charging-pile node on the ``icon_plug``/``icon_ai_plug`` flags, so
+    the same gate is applied here. Payloads that carry neither flag keep the
+    previous behaviour, so stations on older firmware do not lose the entity.
+    """
+    reflux_data = _reflux_data(station_data)
+    if _optional_float(reflux_data.get("pile_power")) is None:
+        return False
+    flags = _ev_charger_flags(reflux_data)
+    if not flags:
+        return True
+    return any(_flag_is_set(flag) for flag in flags)
+
+
+def get_ev_charger_power(station_data: dict[str, Any] | None) -> float | None:
+    """Return EV charger power, or 0 W when no charging pile is active.
+
+    The station keeps reporting a ``pile_power`` value while the icon flags say
+    no pile is connected; that value is not charger telemetry, so it is replaced
+    by an explicit 0 rather than published or dropped. Keeping the entity at 0
+    (instead of unavailable) avoids gaps in long-term statistics.
+    """
+    reflux_data = _reflux_data(station_data)
+    power = _optional_float(reflux_data.get("pile_power"))
+    if power is None:
+        return None
+    flags = _ev_charger_flags(reflux_data)
+    if flags and not any(_flag_is_set(flag) for flag in flags):
+        return 0.0
+    return power
+
+
 def has_battery_telemetry(real_time_data: dict[str, Any] | None) -> bool:
     """Return whether real-time data contains battery telemetry."""
     reflux_data = (real_time_data or {}).get("reflux_station_data", {})
@@ -1116,6 +1167,7 @@ def build_station_capabilities(
 
     return {
         "battery_telemetry": has_battery_telemetry(real_time_data),
+        "ev_charger_available": has_ev_charger({"real_time_data": real_time_data or {}}),
         "battery_settings_readable": battery_settings_readable(battery_settings),
         "battery_settings_writable": battery_settings_writable(battery_settings),
         "relay_settings_readable": relay_settings_readable(relay_settings),

--- a/custom_components/hoymiles_cloud/data.py
+++ b/custom_components/hoymiles_cloud/data.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import json
 import logging
+import math
 from typing import Any
 
 from .const import (
@@ -1089,40 +1090,66 @@ def _flag_is_set(value: Any) -> bool:
 
 
 def has_ev_charger(station_data: dict[str, Any] | None) -> bool:
-    """Return whether the station advertises a charging pile.
-
-    ``pile_power`` is present in the reflux payload of stations that have no EV
-    charger at all, where it does not carry charger telemetry (issue #64: it
-    mirrored PV power on a station with no vehicle connected). The vendor app
-    gates the charging-pile node on the ``icon_plug``/``icon_ai_plug`` flags, so
-    the same gate is applied here. Payloads that carry neither flag keep the
-    previous behaviour, so stations on older firmware do not lose the entity.
-    """
+    """Return whether a charger is advertised by flags or burst telemetry."""
+    station_data = station_data or {}
+    live = (station_data.get("live_data") or {})
+    icon = live.get("icon") if isinstance(live, dict) else None
+    if isinstance(icon, dict) and "pile" in icon:
+        return _flag_is_set(icon["pile"])
     reflux_data = _reflux_data(station_data)
-    if _optional_float(reflux_data.get("pile_power")) is None:
-        return False
     flags = _ev_charger_flags(reflux_data)
-    if not flags:
-        return True
-    return any(_flag_is_set(flag) for flag in flags)
+    if flags:
+        return any(_flag_is_set(flag) for flag in flags)
+    return False
 
 
-def get_ev_charger_power(station_data: dict[str, Any] | None) -> float | None:
-    """Return EV charger power, or 0 W when no charging pile is active.
+def get_fresh_live_data(
+    station_data: dict[str, Any] | None, *, now: datetime | None = None
+) -> dict[str, Any] | None:
+    """Return a burst only when this coordinator cycle fetched it recently.
 
-    The station keeps reporting a ``pile_power`` value while the icon flags say
-    no pile is connected; that value is not charger telemetry, so it is replaced
-    by an explicit 0 rather than published or dropped. Keeping the entity at 0
-    (instead of unavailable) avoids gaps in long-term statistics.
+    The vendor's ``t`` uses station-local time and ``dly`` is a scheduling hint,
+    so neither can establish freshness without a station timezone.
     """
-    reflux_data = _reflux_data(station_data)
-    power = _optional_float(reflux_data.get("pile_power"))
-    if power is None:
+    live = (station_data or {}).get("live_data")
+    if not isinstance(live, dict):
         return None
-    flags = _ev_charger_flags(reflux_data)
-    if flags and not any(_flag_is_set(flag) for flag in flags):
-        return 0.0
+    fetched_at = _optional_float((station_data or {}).get("live_fetched_at"))
+    if fetched_at is None:
+        return None
+    now = now or datetime.now(timezone.utc)
+    age = now.timestamp() - fetched_at
+    max_age = _optional_float((station_data or {}).get("live_max_age")) or 90
+    if age < -30 or age > max_age:
+        return None
+    return live
+
+
+def get_ev_charger_power(
+    station_data: dict[str, Any] | None, *, now: datetime | None = None
+) -> float | None:
+    """Return verified burst charger watts; missing data is never a zero."""
+    if not has_ev_charger(station_data):
+        return None
+    live = get_fresh_live_data(station_data, now=now)
+    es = live.get("es") if live else None
+    if not isinstance(es, dict):
+        return None
+    power = _optional_float(es.get("sp"))
+    if power is None or not math.isfinite(power) or power < 0:
+        return None
     return power
+
+
+def get_grid_connected(station_data: dict[str, Any] | None) -> bool | None:
+    """Read an explicit grid connection flag, if this station provides one."""
+    reflux = _reflux_data(station_data)
+    value = reflux.get("grid_connected")
+    if isinstance(value, bool):
+        return value
+    if value in (0, 1, "0", "1"):
+        return str(value) == "1"
+    return None
 
 
 def has_battery_telemetry(real_time_data: dict[str, Any] | None) -> bool:

--- a/custom_components/hoymiles_cloud/data.py
+++ b/custom_components/hoymiles_cloud/data.py
@@ -752,6 +752,80 @@ def find_placeholder_pv_channels(pv_indicators: dict[str, Any] | None) -> list[i
     return channels
 
 
+def get_microinverter_port_count(microinverter: Any) -> int | None:
+    """Return the port count a microinverter detail payload declares.
+
+    The detail payload from ``/dev/micro/find`` carries ``rule.port`` — the
+    number of DC inputs the hardware has. This is the only field we fetch that
+    states a port count, and it is per-device, matching the ``port`` the
+    module-data endpoint takes.
+    """
+    if not isinstance(microinverter, dict):
+        return None
+    rule = microinverter.get("rule")
+    if not isinstance(rule, dict):
+        return None
+    port = rule.get("port")
+    if isinstance(port, str):
+        port = port.strip()
+        if not port.isdigit():
+            return None
+        port = int(port)
+    if isinstance(port, bool) or not isinstance(port, int) or port < 1:
+        return None
+    return port
+
+
+def expected_pv_channels(microinverters: dict[str, Any] | None) -> list[int]:
+    """Return the PV channels a station's microinverter inventory implies.
+
+    Some firmware omits a channel from the indicators feed entirely rather than
+    reporting it as a placeholder (issue #39), so the channel list cannot be
+    derived from that feed alone. The microinverter's own port count can carry
+    it instead, but only where ``channel N == port N`` is sound — that is, on a
+    single-microinverter station, the same assumption the module-data fallback
+    already rests on. With several microinverters the station-level channel
+    numbering is unknown (#56), so nothing is claimed rather than guessed.
+    """
+    if not microinverters or len(microinverters) != 1:
+        return []
+    port_count = get_microinverter_port_count(next(iter(microinverters.values())))
+    if port_count is None:
+        return []
+    return list(range(1, port_count + 1))
+
+
+def seed_missing_pv_channels(
+    pv_indicators: dict[str, Any] | None,
+    microinverters: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Add placeholder v/i/p entries for channels the feed never reports.
+
+    Seeding turns "channel absent" into "channel present but unset", which is
+    the state ``find_placeholder_pv_channels`` already looks for, so the
+    module-data fallback can fill it like any other placeholder. A channel that
+    the fallback cannot fill stays unset and reads as unknown — visibly missing
+    rather than silently wrong.
+    """
+    if not pv_indicators or not pv_indicators.get("list"):
+        # An empty feed means the fetch failed, not that channels are missing.
+        return pv_indicators or {}
+    expected = expected_pv_channels(microinverters)
+    if not expected:
+        return pv_indicators
+    known = set(discover_pv_channels(pv_indicators))
+    missing = [channel for channel in expected if channel not in known]
+    if not missing:
+        return pv_indicators
+
+    seeded = deepcopy(pv_indicators)
+    items = seeded.setdefault("list", [])
+    for channel in missing:
+        for metric in ("v", "i", "p"):
+            items.append({"key": f"{channel}_pv_{metric}", "val": None})
+    return seeded
+
+
 def _replace_indicator_value(
     items: list[dict[str, Any]],
     key: str,
@@ -1056,6 +1130,11 @@ def build_station_capabilities(
         "ai_available": bool(ai_status),
         "firmware_available": bool(firmware),
         "pv_channels": pv_channels,
+        "expected_pv_channels": expected_pv_channels(microinverters_data),
+        "microinverter_port_counts": {
+            str(mi_id): get_microinverter_port_count(micro)
+            for mi_id, micro in (microinverters_data or {}).items()
+        },
         "microinverter_details_available": bool(microinverters_data),
         "microinverter_detail_count": len(microinverters_data or {}),
         "has_dtu": bool(devices.get("dtus")),

--- a/custom_components/hoymiles_cloud/diagnostics.py
+++ b/custom_components/hoymiles_cloud/diagnostics.py
@@ -50,6 +50,14 @@ REDACT_KEYS = {
     "u",
     "user_name",
     "username",
+    "title",
+    "url",
+    "uri",
+    "signed_url",
+    "sd_uri",
+    "entry_id",
+    "station_id",
+    "station_name",
     # Device and telemetry payloads carry serials/account identifiers under
     # several spellings. They are redacted so the newly added inventory and
     # indicator payloads stay safe to paste into an issue.
@@ -76,6 +84,8 @@ REDACT_KEY_SUFFIXES = (
     "_lng",
     "_latitude",
     "_longitude",
+    "_url",
+    "_uri",
 )
 
 
@@ -120,7 +130,10 @@ def _station_summary(station_data: dict[str, Any]) -> dict[str, Any]:
     """Return a concise station diagnostics summary."""
     devices = station_data.get("devices", {})
     return {
-        "station_info": station_data.get("station_info", {}),
+        "station_info": {
+            key: ("**REDACTED**" if key == "name" else value)
+            for key, value in (station_data.get("station_info") or {}).items()
+        },
         "device_inventory": {
             "dtus": devices.get("dtus", []),
             "inverters": devices.get("inverters", []),
@@ -143,6 +156,7 @@ def _station_summary(station_data: dict[str, Any]) -> dict[str, Any]:
         # grid and load entities exist, so a "missing entities" report cannot
         # be diagnosed without them.
         "real_time_data": station_data.get("real_time_data", {}),
+        "live_data": station_data.get("live_data", {}),
         "pv_indicators": station_data.get("pv_indicators", {}),
         "grid_indicators": station_data.get("grid_indicators", {}),
         "load_indicators": station_data.get("load_indicators", {}),
@@ -202,8 +216,8 @@ async def async_get_config_entry_diagnostics(
             "last_update_success": coordinator.last_update_success,
             "station_count": len(coordinator_data),
             "stations": {
-                station_id: _station_summary(deepcopy(station_data))
-                for station_id, station_data in coordinator_data.items()
+                f"station_{index}": _station_summary(deepcopy(station_data))
+                for index, station_data in enumerate(coordinator_data.values(), 1)
             },
         },
     }

--- a/custom_components/hoymiles_cloud/discovery.py
+++ b/custom_components/hoymiles_cloud/discovery.py
@@ -1,0 +1,38 @@
+"""Idempotent entity discovery on coordinator updates."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable
+
+
+def register_discovery(
+    coordinator: Any,
+    entry: Any,
+    add_entities: Callable[[list[Any]], None],
+    build_entities: Callable[[], Iterable[Any]],
+) -> None:
+    """Add new unique IDs now and after future successful refreshes."""
+    seen_ids: set[str] = set()
+
+    def discover() -> None:
+        new_entities = []
+        pending_ids: set[str] = set()
+        for entity in build_entities():
+            unique_id = entity.unique_id
+            if unique_id in seen_ids or unique_id in pending_ids:
+                continue
+            pending_ids.add(unique_id)
+            new_entities.append(entity)
+        if new_entities:
+            add_entities(new_entities)
+            seen_ids.update(pending_ids)
+
+    discover()
+    entry.async_on_unload(coordinator.async_add_listener(discover))
+
+
+def invalidate_control_cache(coordinator: Any, station_id: str) -> None:
+    """Force the next coordinator refresh to re-read device settings."""
+    callback = getattr(coordinator, "invalidate_control_cache", None)
+    if callback is not None:
+        callback(station_id)

--- a/custom_components/hoymiles_cloud/hoymiles_api.py
+++ b/custom_components/hoymiles_cloud/hoymiles_api.py
@@ -9,6 +9,7 @@ import json
 import logging
 import time
 from typing import Any, Dict, Optional
+from urllib.parse import urlsplit
 
 import aiohttp
 
@@ -26,6 +27,7 @@ from .const import (
     API_STATION_BATTERY_CONFIG_URL,
     API_STATION_DETAILS_URL,
     API_STATION_SETTING_RULE_URL,
+    API_STATION_GET_SD_URI_URL,
     API_REAL_TIME_DATA_URL,
     API_ENERGY_FLOW_STATS_URL,
     API_MICROINVERTERS_URL,
@@ -86,6 +88,14 @@ from .data import (
 from .chart_pb import decode_line_chart
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class LiveDataError(Exception):
+    """Live telemetry is temporarily unavailable or malformed."""
+
+
+class LiveDataAuthError(LiveDataError):
+    """The cloud rejected authentication for live telemetry."""
 
 
 DEFAULT_MODE_SETTINGS: dict[int, dict[str, Any]] = {
@@ -159,6 +169,12 @@ class HoymilesAPI:
         # apart from a genuinely empty list.
         self._fetch_status: Dict[str, Dict[str, Any]] = {}
         self._fetch_failure_keys: set[str] = set()
+        self._live_uris: dict[str, str] = {}
+        self._battery_write_locks: dict[str, asyncio.Lock] = {}
+
+    def _battery_write_lock(self, station_id: str) -> asyncio.Lock:
+        """Serialize read-modify-write commands for one station only."""
+        return self._battery_write_locks.setdefault(str(station_id), asyncio.Lock())
 
     @property
     def device_fetch_status(self) -> Dict[str, Dict[str, Any]]:
@@ -380,7 +396,8 @@ class HoymilesAPI:
     async def _ensure_authenticated(self) -> None:
         """Authenticate if needed before an API request."""
         if not self._token or self.is_token_expired():
-            await self.authenticate()
+            if not await self.authenticate():
+                raise LiveDataAuthError("Hoymiles authentication failed")
 
     async def _post_json(
         self,
@@ -394,9 +411,130 @@ class HoymilesAPI:
         if authenticated:
             await self._ensure_authenticated()
         request_headers = headers or (self._auth_headers() if authenticated else self._json_headers())
-        async with self._session.post(url, headers=request_headers, json=payload) as response:
+        async with self._session.post(
+            url, headers=request_headers, json=payload,
+            timeout=aiohttp.ClientTimeout(total=20),
+        ) as response:
+            status = getattr(response, "status", 200)
+            if status == 401 and authenticated:
+                raise LiveDataAuthError("Hoymiles rejected authentication")
+            if status != 200:
+                raise LiveDataError(f"Hoymiles API request failed with HTTP {status}")
             resp_text = await response.text()
         return json.loads(resp_text)
+
+    @staticmethod
+    def _validate_live_uri(uri: str) -> str:
+        """Accept only Hoymiles' burst endpoint; never reflect a signed URL."""
+        try:
+            parsed = urlsplit(uri)
+            valid = (
+                parsed.scheme == "https"
+                and parsed.hostname == "eurt.hoymiles.com"
+                and parsed.port in (None, 443)
+                and parsed.username is None
+                and parsed.password is None
+                and parsed.path == "/rds/api/0/burst/get"
+                and bool(parsed.query)
+                and not parsed.fragment
+            )
+        except ValueError:
+            valid = False
+        if not valid:
+            raise LiveDataError("Hoymiles returned an invalid live-data endpoint")
+        return uri
+
+    async def _get_live_uri(self, station_id: str) -> str:
+        await self._ensure_authenticated()
+        try:
+            async with self._session.post(
+                API_STATION_GET_SD_URI_URL,
+                headers=self._auth_headers(),
+                json={"sid": int(station_id)},
+                timeout=aiohttp.ClientTimeout(total=10),
+                allow_redirects=False,
+            ) as http_response:
+                if getattr(http_response, "status", 200) == 401:
+                    raise LiveDataAuthError("Hoymiles rejected authentication")
+                if getattr(http_response, "status", 200) != 200:
+                    raise LiveDataError("Hoymiles live-data endpoint request failed")
+                response = await http_response.json()
+        except LiveDataError:
+            raise
+        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError, TypeError):
+            raise LiveDataError("Unable to obtain Hoymiles live-data endpoint") from None
+        if not isinstance(response, dict):
+            raise LiveDataError("Hoymiles returned invalid live-data response")
+        if str(response.get("status")) != "0":
+            if str(response.get("status")) in {"401"}:
+                raise LiveDataAuthError("Hoymiles rejected live-data authorization")
+            raise LiveDataError("Hoymiles live-data endpoint request failed")
+        data = response.get("data")
+        uri = data if isinstance(data, str) else (
+            data.get("uri")
+            if isinstance(data, dict) else None
+        )
+        if not isinstance(uri, str):
+            raise LiveDataError("Hoymiles returned no live-data endpoint")
+        return self._validate_live_uri(uri)
+
+    async def _post_live_burst(self, uri: str) -> dict[str, Any]:
+        """Post without sharing the authenticated session's cookie jar."""
+        # aiohttp injects CookieJar cookies even when no Cookie header is given.
+        # A separate jar keeps credentials off the signed stream host.
+        isolated = isinstance(self._session, aiohttp.ClientSession)
+        session = (
+            aiohttp.ClientSession(
+                connector=self._session.connector,
+                connector_owner=False,
+                cookie_jar=aiohttp.DummyCookieJar(),
+            )
+            if isolated else self._session
+        )
+        try:
+            async with session.post(
+                uri,
+                json={"m": 0, "t": 1, "reflux": 0},
+                headers={"Accept": "application/json", "Content-Type": "application/json"},
+                timeout=aiohttp.ClientTimeout(total=10),
+                allow_redirects=False,
+            ) as response:
+                status = getattr(response, "status", 200)
+                if status != 200:
+                    raise LiveDataError("Hoymiles live-data request failed")
+                return await response.json()
+        finally:
+            if isolated:
+                await session.close()
+
+    async def get_live_data(self, station_id: str) -> dict[str, Any]:
+        """Fetch raw compact burst telemetry through a short-lived signed URI."""
+        key = str(station_id)
+        for attempt in range(2):
+            uri = self._live_uris.get(key)
+            if uri is None:
+                uri = await self._get_live_uri(key)
+                self._live_uris[key] = uri
+            try:
+                result = await self._post_live_burst(uri)
+                if not isinstance(result, dict):
+                    raise LiveDataError("Hoymiles returned invalid live data")
+                if "status" in result and str(result["status"]) != "0":
+                    raise LiveDataError("Hoymiles live-data request failed")
+                data = result.get("data", result)
+                if not isinstance(data, dict):
+                    raise LiveDataError("Hoymiles returned invalid live data")
+                if not isinstance(data.get("es"), dict):
+                    raise LiveDataError("Hoymiles returned incomplete live data")
+                return data
+            except LiveDataAuthError:
+                self._live_uris.pop(key, None)
+                raise
+            except (aiohttp.ClientError, asyncio.TimeoutError, ValueError, LiveDataError):
+                self._live_uris.pop(key, None)
+                if attempt:
+                    raise LiveDataError("Hoymiles live data is unavailable") from None
+        raise LiveDataError("Hoymiles live data is unavailable")
 
     async def _post_bytes(
         self,
@@ -799,7 +937,8 @@ class HoymilesAPI:
                     )
 
                 salt = self._decode_v3_salt(salt_b64)
-                raw_hash = hash_secret_raw(
+                raw_hash = await asyncio.to_thread(
+                    hash_secret_raw,
                     secret=self._password.encode(),
                     salt=salt,
                     time_cost=3,
@@ -1693,7 +1832,7 @@ class HoymilesAPI:
 
     async def _verify_battery_mode_applied(
         self, station_id: str, mode: int, mode_settings: dict[str, Any]
-    ) -> bool:
+    ) -> bool | None:
         """Re-read the settings and confirm the write actually took effect.
 
         The direct endpoint has been observed answering ``{"status": "0",
@@ -1714,14 +1853,15 @@ class HoymilesAPI:
             if battery_settings_readable(settings):
                 break
         else:
-            # Cannot confirm either way; do not claim the write failed.
+            # An unverified write must not be reported as applied or retried
+            # through another transport (which could submit a duplicate job).
             _LOGGER.debug(
                 "Could not verify battery write for station %s: settings stayed "
                 "unreadable after %s attempts",
                 station_id,
                 BATTERY_WRITE_VERIFY_ATTEMPTS,
             )
-            return True
+            return None
 
         active_mode = (settings.get("data") or {}).get("mode")
         if active_mode != mode:
@@ -1768,8 +1908,11 @@ class HoymilesAPI:
         state back.
         """
         if await self._write_battery_mode_payload(station_id, mode, mode_settings):
-            if await self._verify_battery_mode_applied(station_id, mode, mode_settings):
+            verified = await self._verify_battery_mode_applied(station_id, mode, mode_settings)
+            if verified is True:
                 return True
+            if verified is None:
+                return False
             _LOGGER.debug(
                 "Async battery write for station %s mode %s reported success but "
                 "did not apply; trying the direct endpoint",
@@ -1780,7 +1923,7 @@ class HoymilesAPI:
         if not await self.set_battery_config_direct(station_id, mode, mode_settings):
             return False
 
-        if await self._verify_battery_mode_applied(station_id, mode, mode_settings):
+        if await self._verify_battery_mode_applied(station_id, mode, mode_settings) is True:
             return True
 
         _LOGGER.error(
@@ -1909,6 +2052,10 @@ class HoymilesAPI:
             )
             return None, {}
 
+        if mode not in current_settings.get("available_modes", []):
+            _LOGGER.warning("Battery mode %s is unsupported for station %s", mode, station_id)
+            return None, {}
+
         mode_settings = get_mode_settings(current_settings, mode) or self._default_mode_settings(mode)
 
         if mode == BATTERY_MODE_ECONOMY:
@@ -1933,7 +2080,18 @@ class HoymilesAPI:
             _LOGGER.error("Battery mode settings must be a dictionary")
             return False
 
-        _, current_mode_settings = await self._get_writable_mode_settings(station_id, mode)
+        async with self._battery_write_lock(station_id):
+            return await self._set_battery_mode_settings_locked(
+                station_id, mode, settings, merge=merge
+            )
+
+    async def _set_battery_mode_settings_locked(
+        self, station_id: str, mode: int, settings: dict[str, Any], *, merge: bool
+    ) -> bool:
+        """Apply settings while the caller holds this station's write lock."""
+        current_settings, current_mode_settings = await self._get_writable_mode_settings(station_id, mode)
+        if current_settings is None:
+            return False
         if not current_mode_settings and not settings and mode not in DEFAULT_MODE_SETTINGS:
             return False
 
@@ -1955,16 +2113,19 @@ class HoymilesAPI:
             _LOGGER.error("Invalid battery mode: %s", mode)
             return False
 
-        _, mode_settings = await self._get_writable_mode_settings(station_id, mode)
-        if not mode_settings and mode not in DEFAULT_MODE_SETTINGS:
-            return False
+        async with self._battery_write_lock(station_id):
+            current_settings, mode_settings = await self._get_writable_mode_settings(station_id, mode)
+            if current_settings is None:
+                return False
+            if not mode_settings and mode not in DEFAULT_MODE_SETTINGS:
+                return False
 
-        _LOGGER.info(
-            "Setting battery mode to %s for station ID: %s",
-            BATTERY_MODES.get(mode),
-            station_id,
-        )
-        return await self.apply_battery_mode_payload(station_id, mode, mode_settings)
+            _LOGGER.info(
+                "Setting battery mode to %s for station ID: %s",
+                BATTERY_MODES.get(mode),
+                station_id,
+            )
+            return await self.apply_battery_mode_payload(station_id, mode, mode_settings)
 
     async def set_reserve_soc(self, station_id: str, reserve_soc: int) -> bool:
         """Set battery reserve SOC for a station."""
@@ -1972,22 +2133,21 @@ class HoymilesAPI:
             _LOGGER.error("Invalid reserve SOC value: %s", reserve_soc)
             return False
 
-        current_settings = await self.get_battery_settings(station_id)
-        if not battery_settings_readable(current_settings):
-            _LOGGER.warning(
-                "Skipping reserve SOC update because settings are unavailable for station %s",
-                station_id,
-            )
-            return False
+        async with self._battery_write_lock(station_id):
+            current_settings = await self.get_battery_settings(station_id)
+            if not battery_settings_readable(current_settings):
+                _LOGGER.warning(
+                    "Skipping reserve SOC update because settings are unavailable for station %s",
+                    station_id,
+                )
+                return False
 
-        current_mode = current_settings.get("data", {}).get(
-            "mode", BATTERY_MODE_SELF_CONSUMPTION
-        )
-        return await self.set_battery_mode_settings(
-            station_id,
-            current_mode,
-            {"reserve_soc": reserve_soc},
-        )
+            current_mode = current_settings.get("data", {}).get(
+                "mode", BATTERY_MODE_SELF_CONSUMPTION
+            )
+            return await self._set_battery_mode_settings_locked(
+                station_id, current_mode, {"reserve_soc": reserve_soc}, merge=True
+            )
 
     async def set_peak_shaving_settings(
         self,

--- a/custom_components/hoymiles_cloud/hoymiles_api.py
+++ b/custom_components/hoymiles_cloud/hoymiles_api.py
@@ -481,7 +481,9 @@ class HoymilesAPI:
     async def _post_live_burst(self, uri: str) -> dict[str, Any]:
         """Post without sharing the authenticated session's cookie jar."""
         # aiohttp injects CookieJar cookies even when no Cookie header is given.
-        # A separate jar keeps credentials off the signed stream host.
+        # The stream requires account authorization, but must not inherit cookies.
+        uri = self._validate_live_uri(uri)
+        await self._ensure_authenticated()
         isolated = isinstance(self._session, aiohttp.ClientSession)
         session = (
             aiohttp.ClientSession(
@@ -495,7 +497,11 @@ class HoymilesAPI:
             async with session.post(
                 uri,
                 json={"m": 0, "t": 1, "reflux": 0},
-                headers={"Accept": "application/json", "Content-Type": "application/json"},
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "Authorization": self._token,
+                },
                 timeout=aiohttp.ClientTimeout(total=10),
                 allow_redirects=False,
             ) as response:

--- a/custom_components/hoymiles_cloud/manifest.json
+++ b/custom_components/hoymiles_cloud/manifest.json
@@ -14,5 +14,5 @@
     "argon2-cffi>=21.3.0"
   ],
   "single_config_entry": false,
-  "version": "1.3.1"
+  "version": "1.3.1rc1"
 }

--- a/custom_components/hoymiles_cloud/manifest.json
+++ b/custom_components/hoymiles_cloud/manifest.json
@@ -14,5 +14,5 @@
     "argon2-cffi>=21.3.0"
   ],
   "single_config_entry": false,
-  "version": "1.3.1rc1"
+  "version": "1.3.1rc2"
 }

--- a/custom_components/hoymiles_cloud/manifest.json
+++ b/custom_components/hoymiles_cloud/manifest.json
@@ -14,5 +14,5 @@
     "argon2-cffi>=21.3.0"
   ],
   "single_config_entry": false,
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/custom_components/hoymiles_cloud/models.py
+++ b/custom_components/hoymiles_cloud/models.py
@@ -82,6 +82,10 @@ class StationData:
 
     station_info: dict[str, Any] = field(default_factory=dict)
     real_time_data: dict[str, Any] = field(default_factory=dict)
+    live_data: dict[str, Any] = field(default_factory=dict)
+    live_fetched_at: float | None = None
+    live_max_age: int = 90
+    telemetry_available: bool = False
     energy_flow: dict[str, Any] = field(default_factory=dict)
     pv_indicators: dict[str, Any] = field(default_factory=dict)
     grid_indicators: dict[str, Any] = field(default_factory=dict)

--- a/custom_components/hoymiles_cloud/number.py
+++ b/custom_components/hoymiles_cloud/number.py
@@ -1,6 +1,9 @@
 """Number platform for Hoymiles Cloud integration."""
 from __future__ import annotations
 
+# Coordinator polls and API writes manage their own scheduling.
+PARALLEL_UPDATES = 0
+
 from typing import Any
 
 from homeassistant.components.number import NumberEntity, NumberMode
@@ -12,6 +15,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
+from .discovery import invalidate_control_cache, register_discovery
 from .const import (
     BATTERY_MODE_ECONOMY,
     BATTERY_MODE_FORCE_CHARGE,
@@ -44,164 +48,168 @@ async def async_setup_entry(
     """Set up the Hoymiles number platform."""
     runtime_data = hass.data[DOMAIN][entry.entry_id]
     coordinator = runtime_data["coordinator"]
+    coordinator.invalidate_control_cache = runtime_data["invalidate_control_cache"]
     stations = runtime_data["stations"]
     api = runtime_data["api"]
     update_soc = runtime_data["update_soc"]
     set_schedule_editor_field = runtime_data["set_schedule_editor_field"]
 
-    entities = []
-    for station_id, station_name in stations.items():
-        station_data = coordinator.data.get(station_id, {}) if coordinator.data else {}
-        battery_settings = station_data.get("battery_settings", {})
-        if not battery_settings_writable(battery_settings):
-            continue
+    def build_entities() -> list:
+        entities = []
+        for station_id, station_name in stations.items():
+            station_data = coordinator.data.get(station_id, {}) if coordinator.data else {}
+            battery_settings = station_data.get("battery_settings", {})
+            if not battery_settings_writable(battery_settings):
+                continue
 
-        supported_modes = get_allowed_battery_modes(
-            battery_settings,
-            station_data.get("setting_rules", {}),
-        )
-        for mode in supported_modes:
-            mode_settings = get_mode_settings(battery_settings, mode)
-            if "reserve_soc" in mode_settings:
-                entities.append(
-                    HoymilesBatteryReserveSOC(
-                        coordinator=coordinator,
-                        api=api,
-                        station_id=station_id,
-                        station_name=station_name,
-                        mode=mode,
-                        update_soc_callback=update_soc,
-                    )
-                )
-            if mode in (BATTERY_MODE_FORCE_CHARGE, BATTERY_MODE_FORCE_DISCHARGE) and "max_power" in mode_settings:
-                entities.append(
-                    HoymilesBatteryMaxPower(
-                        coordinator=coordinator,
-                        api=api,
-                        station_id=station_id,
-                        station_name=station_name,
-                        mode=mode,
-                    )
-                )
-
-        peak_settings = get_mode_settings(battery_settings, BATTERY_MODE_PEAK_SHAVING)
-        if peak_settings:
-            if "max_soc" in peak_settings:
-                entities.append(
-                    HoymilesPeakShavingMaxSOC(
-                        coordinator=coordinator,
-                        api=api,
-                        station_id=station_id,
-                        station_name=station_name,
-                    )
-                )
-            if "meter_power" in peak_settings:
-                entities.append(
-                    HoymilesPeakShavingMeterPower(
-                        coordinator=coordinator,
-                        api=api,
-                        station_id=station_id,
-                        station_name=station_name,
-                    )
-                )
-
-        if station_data.get("schedule_editor", {}).get("available_modes"):
-            entities.extend(
-                [
-                    HoymilesScheduleNumberEntity(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        set_schedule_editor_field,
-                        BATTERY_MODE_TIME_OF_USE,
-                        "time_of_use_charge_power",
-                        "Time of Use Charge Power",
-                        _tou_period_path,
-                        "c_power",
-                        0,
-                        100,
-                        1,
-                        PERCENTAGE,
-                    ),
-                    HoymilesScheduleNumberEntity(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        set_schedule_editor_field,
-                        BATTERY_MODE_TIME_OF_USE,
-                        "time_of_use_discharge_power",
-                        "Time of Use Discharge Power",
-                        _tou_period_path,
-                        "dc_power",
-                        0,
-                        100,
-                        1,
-                        PERCENTAGE,
-                    ),
-                    HoymilesScheduleNumberEntity(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        set_schedule_editor_field,
-                        BATTERY_MODE_TIME_OF_USE,
-                        "time_of_use_charge_soc",
-                        "Time of Use Charge SOC",
-                        _tou_period_path,
-                        "charge_soc",
-                        0,
-                        100,
-                        1,
-                        PERCENTAGE,
-                    ),
-                    HoymilesScheduleNumberEntity(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        set_schedule_editor_field,
-                        BATTERY_MODE_TIME_OF_USE,
-                        "time_of_use_discharge_soc",
-                        "Time of Use Discharge SOC",
-                        _tou_period_path,
-                        "dis_charge_soc",
-                        0,
-                        100,
-                        1,
-                        PERCENTAGE,
-                    ),
-                    HoymilesScheduleNumberEntity(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        set_schedule_editor_field,
-                        BATTERY_MODE_ECONOMY,
-                        "economy_duration_in",
-                        "Economy Duration In",
-                        _economy_duration_path,
-                        "in",
-                        0,
-                        100,
-                        0.1,
-                        None,
-                    ),
-                    HoymilesScheduleNumberEntity(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        set_schedule_editor_field,
-                        BATTERY_MODE_ECONOMY,
-                        "economy_duration_out",
-                        "Economy Duration Out",
-                        _economy_duration_path,
-                        "out",
-                        0,
-                        100,
-                        0.1,
-                        None,
-                    ),
-                ]
+            supported_modes = get_allowed_battery_modes(
+                battery_settings,
+                station_data.get("setting_rules", {}),
             )
+            for mode in supported_modes:
+                mode_settings = get_mode_settings(battery_settings, mode)
+                if "reserve_soc" in mode_settings:
+                    entities.append(
+                        HoymilesBatteryReserveSOC(
+                            coordinator=coordinator,
+                            api=api,
+                            station_id=station_id,
+                            station_name=station_name,
+                            mode=mode,
+                            update_soc_callback=update_soc,
+                        )
+                    )
+                if mode in (BATTERY_MODE_FORCE_CHARGE, BATTERY_MODE_FORCE_DISCHARGE) and "max_power" in mode_settings:
+                    entities.append(
+                        HoymilesBatteryMaxPower(
+                            coordinator=coordinator,
+                            api=api,
+                            station_id=station_id,
+                            station_name=station_name,
+                            mode=mode,
+                        )
+                    )
 
-    async_add_entities(entities)
+            peak_settings = get_mode_settings(battery_settings, BATTERY_MODE_PEAK_SHAVING)
+            if peak_settings:
+                if "max_soc" in peak_settings:
+                    entities.append(
+                        HoymilesPeakShavingMaxSOC(
+                            coordinator=coordinator,
+                            api=api,
+                            station_id=station_id,
+                            station_name=station_name,
+                        )
+                    )
+                if "meter_power" in peak_settings:
+                    entities.append(
+                        HoymilesPeakShavingMeterPower(
+                            coordinator=coordinator,
+                            api=api,
+                            station_id=station_id,
+                            station_name=station_name,
+                        )
+                    )
+
+            if station_data.get("schedule_editor", {}).get("available_modes"):
+                entities.extend(
+                    [
+                        HoymilesScheduleNumberEntity(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            set_schedule_editor_field,
+                            BATTERY_MODE_TIME_OF_USE,
+                            "time_of_use_charge_power",
+                            "Time of Use Charge Power",
+                            _tou_period_path,
+                            "c_power",
+                            0,
+                            100,
+                            1,
+                            PERCENTAGE,
+                        ),
+                        HoymilesScheduleNumberEntity(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            set_schedule_editor_field,
+                            BATTERY_MODE_TIME_OF_USE,
+                            "time_of_use_discharge_power",
+                            "Time of Use Discharge Power",
+                            _tou_period_path,
+                            "dc_power",
+                            0,
+                            100,
+                            1,
+                            PERCENTAGE,
+                        ),
+                        HoymilesScheduleNumberEntity(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            set_schedule_editor_field,
+                            BATTERY_MODE_TIME_OF_USE,
+                            "time_of_use_charge_soc",
+                            "Time of Use Charge SOC",
+                            _tou_period_path,
+                            "charge_soc",
+                            0,
+                            100,
+                            1,
+                            PERCENTAGE,
+                        ),
+                        HoymilesScheduleNumberEntity(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            set_schedule_editor_field,
+                            BATTERY_MODE_TIME_OF_USE,
+                            "time_of_use_discharge_soc",
+                            "Time of Use Discharge SOC",
+                            _tou_period_path,
+                            "dis_charge_soc",
+                            0,
+                            100,
+                            1,
+                            PERCENTAGE,
+                        ),
+                        HoymilesScheduleNumberEntity(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            set_schedule_editor_field,
+                            BATTERY_MODE_ECONOMY,
+                            "economy_duration_in",
+                            "Economy Duration In",
+                            _economy_duration_path,
+                            "in",
+                            0,
+                            100,
+                            0.1,
+                            None,
+                        ),
+                        HoymilesScheduleNumberEntity(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            set_schedule_editor_field,
+                            BATTERY_MODE_ECONOMY,
+                            "economy_duration_out",
+                            "Economy Duration Out",
+                            _economy_duration_path,
+                            "out",
+                            0,
+                            100,
+                            0.1,
+                            None,
+                        ),
+                    ]
+                )
+
+        return entities
+
+    register_discovery(coordinator, entry, async_add_entities, build_entities)
 
 
 class HoymilesBatteryNumberEntity(CoordinatorEntity, NumberEntity):
@@ -294,6 +302,7 @@ class HoymilesBatteryReserveSOC(HoymilesBatteryNumberEntity):
             )
 
         await self._update_soc(self._station_id, self._get_storage_key(), int(value))
+        invalidate_control_cache(self.coordinator, self._station_id)
         await self.coordinator.async_request_refresh()
         self.async_write_ha_state()
 
@@ -339,6 +348,7 @@ class HoymilesBatteryMaxPower(HoymilesBatteryNumberEntity):
                 "See the Home Assistant log for the API response."
             )
 
+        invalidate_control_cache(self.coordinator, self._station_id)
         await self.coordinator.async_request_refresh()
         self.async_write_ha_state()
 
@@ -387,6 +397,7 @@ class HoymilesPeakShavingMaxSOC(HoymilesBatteryNumberEntity):
                 "See the Home Assistant log for the API response."
             )
 
+        invalidate_control_cache(self.coordinator, self._station_id)
         await self.coordinator.async_request_refresh()
         self.async_write_ha_state()
 
@@ -435,6 +446,7 @@ class HoymilesPeakShavingMeterPower(HoymilesBatteryNumberEntity):
                 "See the Home Assistant log for the API response."
             )
 
+        invalidate_control_cache(self.coordinator, self._station_id)
         await self.coordinator.async_request_refresh()
         self.async_write_ha_state()
 

--- a/custom_components/hoymiles_cloud/select.py
+++ b/custom_components/hoymiles_cloud/select.py
@@ -1,6 +1,9 @@
 """Select platform for Hoymiles Cloud integration."""
 from __future__ import annotations
 
+# Coordinator polls and API writes manage their own scheduling.
+PARALLEL_UPDATES = 0
+
 import logging
 from typing import Optional
 
@@ -11,6 +14,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
+from .discovery import invalidate_control_cache, register_discovery
 from .const import BATTERY_MODES, DOMAIN
 from .const import BATTERY_MODE_ECONOMY, BATTERY_MODE_TIME_OF_USE
 from .data import battery_settings_writable, get_allowed_battery_modes
@@ -42,63 +46,67 @@ async def async_setup_entry(
     """Set up Hoymiles Cloud select entities."""
     runtime_data = hass.data[DOMAIN][entry.entry_id]
     coordinator = runtime_data["coordinator"]
+    coordinator.invalidate_control_cache = runtime_data["invalidate_control_cache"]
     stations = runtime_data["stations"]
     api = runtime_data["api"]
     set_schedule_editor_selection = runtime_data["set_schedule_editor_selection"]
 
-    entities = []
-    for station_id, station_name in stations.items():
-        station_data = coordinator.data.get(station_id, {}) if coordinator.data else {}
-        battery_settings = station_data.get("battery_settings", {})
-        if battery_settings_writable(battery_settings) and get_allowed_battery_modes(
-            battery_settings,
-            station_data.get("setting_rules", {}),
-        ):
-            entities.append(
-                HoymilesBatteryModeSelect(
-                    coordinator=coordinator,
-                    api=api,
-                    station_id=station_id,
-                    station_name=station_name,
+    def build_entities() -> list:
+        entities = []
+        for station_id, station_name in stations.items():
+            station_data = coordinator.data.get(station_id, {}) if coordinator.data else {}
+            battery_settings = station_data.get("battery_settings", {})
+            if battery_settings_writable(battery_settings) and get_allowed_battery_modes(
+                battery_settings,
+                station_data.get("setting_rules", {}),
+            ):
+                entities.append(
+                    HoymilesBatteryModeSelect(
+                        coordinator=coordinator,
+                        api=api,
+                        station_id=station_id,
+                        station_name=station_name,
+                    )
                 )
-            )
-        if station_data.get("schedule_editor", {}).get("available_modes"):
-            entities.extend(
-                [
-                    HoymilesScheduleEditorModeSelect(
-                        coordinator=coordinator,
-                        station_id=station_id,
-                        station_name=station_name,
-                        set_selection=set_schedule_editor_selection,
-                    ),
-                    HoymilesTimeOfUsePeriodSelect(
-                        coordinator=coordinator,
-                        station_id=station_id,
-                        station_name=station_name,
-                        set_selection=set_schedule_editor_selection,
-                    ),
-                    HoymilesEconomyWindowSelect(
-                        coordinator=coordinator,
-                        station_id=station_id,
-                        station_name=station_name,
-                        set_selection=set_schedule_editor_selection,
-                    ),
-                    HoymilesEconomyWeekGroupSelect(
-                        coordinator=coordinator,
-                        station_id=station_id,
-                        station_name=station_name,
-                        set_selection=set_schedule_editor_selection,
-                    ),
-                    HoymilesEconomyDurationTypeSelect(
-                        coordinator=coordinator,
-                        station_id=station_id,
-                        station_name=station_name,
-                        set_selection=set_schedule_editor_selection,
-                    ),
-                ]
-            )
+            if station_data.get("schedule_editor", {}).get("available_modes"):
+                entities.extend(
+                    [
+                        HoymilesScheduleEditorModeSelect(
+                            coordinator=coordinator,
+                            station_id=station_id,
+                            station_name=station_name,
+                            set_selection=set_schedule_editor_selection,
+                        ),
+                        HoymilesTimeOfUsePeriodSelect(
+                            coordinator=coordinator,
+                            station_id=station_id,
+                            station_name=station_name,
+                            set_selection=set_schedule_editor_selection,
+                        ),
+                        HoymilesEconomyWindowSelect(
+                            coordinator=coordinator,
+                            station_id=station_id,
+                            station_name=station_name,
+                            set_selection=set_schedule_editor_selection,
+                        ),
+                        HoymilesEconomyWeekGroupSelect(
+                            coordinator=coordinator,
+                            station_id=station_id,
+                            station_name=station_name,
+                            set_selection=set_schedule_editor_selection,
+                        ),
+                        HoymilesEconomyDurationTypeSelect(
+                            coordinator=coordinator,
+                            station_id=station_id,
+                            station_name=station_name,
+                            set_selection=set_schedule_editor_selection,
+                        ),
+                    ]
+                )
 
-    async_add_entities(entities)
+        return entities
+
+    register_discovery(coordinator, entry, async_add_entities, build_entities)
 
 
 class HoymilesBatteryModeSelect(CoordinatorEntity, SelectEntity):
@@ -158,6 +166,7 @@ class HoymilesBatteryModeSelect(CoordinatorEntity, SelectEntity):
                 _LOGGER.error("Failed to set battery mode to %s (ID: %s)", option, mode_id)
                 return
 
+            invalidate_control_cache(self.coordinator, self._station_id)
             await self.coordinator.async_request_refresh()
             self.async_write_ha_state()
             return

--- a/custom_components/hoymiles_cloud/sensor.py
+++ b/custom_components/hoymiles_cloud/sensor.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+# Coordinator polls and API writes manage their own scheduling.
+PARALLEL_UPDATES = 0
+
 import logging
 from dataclasses import dataclass
 from datetime import datetime
@@ -30,6 +33,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
+from .discovery import register_discovery
 from .const import BATTERY_MODES, DOMAIN, METER_LOCATION_NAMES
 from .data import (
     battery_settings_readable,
@@ -66,6 +70,12 @@ from .schedule_editor import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+_NON_TELEMETRY_SENSOR_KEYS = {
+    "electricity_buy_price", "electricity_sell_price", "ai_status",
+    "ai_compound_mode", "firmware_status", "reported_inverter_count",
+    "battery_settings_access",
+}
 
 
 def safe_int_convert(value: Any) -> int | None:
@@ -467,7 +477,7 @@ STATION_SENSORS: list[HoymilesSensorDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         exists_fn=has_ev_charger,
-        available_fn=lambda data: safe_float_convert(get_reflux_data(data).get("pile_power")) is not None,
+        available_fn=lambda data: get_ev_charger_power(data) is not None,
         value_fn=get_ev_charger_power,
     ),
     HoymilesSensorDescription(
@@ -647,225 +657,229 @@ async def async_setup_entry(
     coordinator = runtime_data["coordinator"]
     stations = runtime_data["stations"]
 
-    entities: list[SensorEntity] = []
-    for station_id, station_name in stations.items():
-        station_data = get_station_data(coordinator, station_id)
+    def build_entities() -> list[SensorEntity]:
+        """Add newly discovered station, device and PV entities once."""
+        entities: list[SensorEntity] = []
+        for station_id, station_name in stations.items():
+            station_data = get_station_data(coordinator, station_id)
 
-        for description in STATION_SENSORS:
-            if description.exists_fn and not description.exists_fn(station_data):
-                continue
-            entities.append(
-                HoymilesAggregateSensor(
-                    coordinator=coordinator,
-                    description=description,
-                    station_id=station_id,
-                    station_name=station_name,
-                )
-            )
-
-        if battery_settings_readable(station_data.get("battery_settings", {})):
-            entities.append(HoymilesBatteryModeSensor(coordinator, station_id, station_name))
-
-        if station_data.get("schedule_editor", {}).get("available_modes"):
-            entities.extend(
-                [
-                    HoymilesScheduleEditorModeSensor(coordinator, station_id, station_name),
-                    HoymilesScheduleSummarySensor(coordinator, station_id, station_name, 2),
-                    HoymilesScheduleSummarySensor(coordinator, station_id, station_name, 8),
-                    HoymilesScheduleCountSensor(coordinator, station_id, station_name, 2),
-                    HoymilesScheduleCountSensor(coordinator, station_id, station_name, 8),
-                    HoymilesScheduleEditorValidationSensor(coordinator, station_id, station_name),
-                    HoymilesScheduleEditorDirtySensor(coordinator, station_id, station_name),
-                ]
-            )
-
-        for channel in discover_pv_channels(station_data.get("pv_indicators", {})):
-            entities.extend(
-                [
-                    HoymilesPVChannelSensor(coordinator, station_id, station_name, channel, "v"),
-                    HoymilesPVChannelSensor(coordinator, station_id, station_name, channel, "i"),
-                    HoymilesPVChannelSensor(coordinator, station_id, station_name, channel, "p"),
-                ]
-            )
-
-        for entity_key, label, indicator_key, unit, device_class, precision in GRID_INDICATOR_SPECS:
-            if has_grid_indicator(station_data, indicator_key):
+            for description in STATION_SENSORS:
+                if description.exists_fn and not description.exists_fn(station_data):
+                    continue
                 entities.append(
-                    HoymilesGridIndicatorSensor(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        entity_key,
-                        label,
-                        indicator_key,
-                        unit,
-                        device_class,
-                        precision,
+                    HoymilesAggregateSensor(
+                        coordinator=coordinator,
+                        description=description,
+                        station_id=station_id,
+                        station_name=station_name,
                     )
                 )
 
-        for inverter in station_data.get("devices", {}).get("inverters", []):
-            entities.extend(
-                [
-                    HoymilesDeviceAttributeSensor(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        "inverters",
-                        inverter,
-                        "model",
-                        "Inverter Model",
-                        "model_no",
-                        build_inverter_device_info,
-                    ),
-                    HoymilesDeviceAttributeSensor(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        "inverters",
-                        inverter,
-                        "firmware",
-                        "Inverter Firmware Version",
-                        "soft_ver",
-                        build_inverter_device_info,
-                        entity_category=EntityCategory.DIAGNOSTIC,
-                        enabled_default=False,
-                    ),
-                    HoymilesDeviceAttributeSensor(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        "inverters",
-                        inverter,
-                        "hardware",
-                        "Inverter Hardware Version",
-                        "hard_ver",
-                        build_inverter_device_info,
-                        entity_category=EntityCategory.DIAGNOSTIC,
-                        enabled_default=False,
-                    ),
-                ]
-            )
+            if battery_settings_readable(station_data.get("battery_settings", {})):
+                entities.append(HoymilesBatteryModeSensor(coordinator, station_id, station_name))
 
-        for battery in station_data.get("devices", {}).get("batteries", []):
-            entities.extend(
-                [
-                    HoymilesDeviceAttributeSensor(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        "batteries",
-                        battery,
-                        "capacity",
-                        "Battery Capacity",
-                        "cap",
-                        build_battery_device_info,
-                    ),
-                    HoymilesDeviceAttributeSensor(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        "batteries",
-                        battery,
-                        "bms_type",
-                        "Battery BMS Type",
-                        "bms_type",
-                        build_battery_device_info,
-                        entity_category=EntityCategory.DIAGNOSTIC,
-                    ),
-                    HoymilesDeviceAttributeSensor(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        "batteries",
-                        battery,
-                        "firmware",
-                        "Battery Firmware Version",
-                        "soft_ver",
-                        build_battery_device_info,
-                        entity_category=EntityCategory.DIAGNOSTIC,
-                        enabled_default=False,
-                    ),
-                    HoymilesDeviceAttributeSensor(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        "batteries",
-                        battery,
-                        "hardware",
-                        "Battery Hardware Version",
-                        "hard_ver",
-                        build_battery_device_info,
-                        entity_category=EntityCategory.DIAGNOSTIC,
-                        enabled_default=False,
-                    ),
-                ]
-            )
+            if station_data.get("schedule_editor", {}).get("available_modes"):
+                entities.extend(
+                    [
+                        HoymilesScheduleEditorModeSensor(coordinator, station_id, station_name),
+                        HoymilesScheduleSummarySensor(coordinator, station_id, station_name, 2),
+                        HoymilesScheduleSummarySensor(coordinator, station_id, station_name, 8),
+                        HoymilesScheduleCountSensor(coordinator, station_id, station_name, 2),
+                        HoymilesScheduleCountSensor(coordinator, station_id, station_name, 8),
+                        HoymilesScheduleEditorValidationSensor(coordinator, station_id, station_name),
+                        HoymilesScheduleEditorDirtySensor(coordinator, station_id, station_name),
+                    ]
+                )
 
-        for meter in station_data.get("devices", {}).get("meters", []):
-            entities.extend(
-                [
-                    HoymilesDeviceAttributeSensor(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        "meters",
-                        meter,
-                        "location",
-                        "Meter Location",
-                        "location",
-                        build_meter_device_info,
-                        value_transform=lambda value: METER_LOCATION_NAMES.get(value, str(value)),
-                        entity_category=EntityCategory.DIAGNOSTIC,
-                    ),
-                    HoymilesDeviceAttributeSensor(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        "meters",
-                        meter,
-                        "ct_gain",
-                        "Meter CT Gain",
-                        "ct_gain",
-                        build_meter_device_info,
-                        value_transform=safe_float_convert,
-                        entity_category=EntityCategory.DIAGNOSTIC,
-                    ),
-                ]
-            )
+            for channel in discover_pv_channels(station_data.get("pv_indicators", {})):
+                entities.extend(
+                    [
+                        HoymilesPVChannelSensor(coordinator, station_id, station_name, channel, "v"),
+                        HoymilesPVChannelSensor(coordinator, station_id, station_name, channel, "i"),
+                        HoymilesPVChannelSensor(coordinator, station_id, station_name, channel, "p"),
+                    ]
+                )
 
-        for dtu in station_data.get("devices", {}).get("dtus", []):
-            entities.extend(
-                [
-                    HoymilesDeviceAttributeSensor(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        "dtus",
-                        dtu,
-                        "serial",
-                        "DTU Serial",
-                        "sn",
-                        build_dtu_device_info,
-                        entity_category=EntityCategory.DIAGNOSTIC,
-                        enabled_default=False,
-                    ),
-                    HoymilesDeviceAttributeSensor(
-                        coordinator,
-                        station_id,
-                        station_name,
-                        "dtus",
-                        dtu,
-                        "device_type",
-                        "DTU Device Type",
-                        "type",
-                        build_dtu_device_info,
-                        entity_category=EntityCategory.DIAGNOSTIC,
-                    ),
-                ]
-            )
+            for entity_key, label, indicator_key, unit, device_class, precision in GRID_INDICATOR_SPECS:
+                if has_grid_indicator(station_data, indicator_key):
+                    entities.append(
+                        HoymilesGridIndicatorSensor(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            entity_key,
+                            label,
+                            indicator_key,
+                            unit,
+                            device_class,
+                            precision,
+                        )
+                    )
 
-    async_add_entities(entities)
+            for inverter in station_data.get("devices", {}).get("inverters", []):
+                entities.extend(
+                    [
+                        HoymilesDeviceAttributeSensor(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            "inverters",
+                            inverter,
+                            "model",
+                            "Inverter Model",
+                            "model_no",
+                            build_inverter_device_info,
+                        ),
+                        HoymilesDeviceAttributeSensor(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            "inverters",
+                            inverter,
+                            "firmware",
+                            "Inverter Firmware Version",
+                            "soft_ver",
+                            build_inverter_device_info,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                            enabled_default=False,
+                        ),
+                        HoymilesDeviceAttributeSensor(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            "inverters",
+                            inverter,
+                            "hardware",
+                            "Inverter Hardware Version",
+                            "hard_ver",
+                            build_inverter_device_info,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                            enabled_default=False,
+                        ),
+                    ]
+                )
+
+            for battery in station_data.get("devices", {}).get("batteries", []):
+                entities.extend(
+                    [
+                        HoymilesDeviceAttributeSensor(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            "batteries",
+                            battery,
+                            "capacity",
+                            "Battery Capacity",
+                            "cap",
+                            build_battery_device_info,
+                        ),
+                        HoymilesDeviceAttributeSensor(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            "batteries",
+                            battery,
+                            "bms_type",
+                            "Battery BMS Type",
+                            "bms_type",
+                            build_battery_device_info,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                        ),
+                        HoymilesDeviceAttributeSensor(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            "batteries",
+                            battery,
+                            "firmware",
+                            "Battery Firmware Version",
+                            "soft_ver",
+                            build_battery_device_info,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                            enabled_default=False,
+                        ),
+                        HoymilesDeviceAttributeSensor(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            "batteries",
+                            battery,
+                            "hardware",
+                            "Battery Hardware Version",
+                            "hard_ver",
+                            build_battery_device_info,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                            enabled_default=False,
+                        ),
+                    ]
+                )
+
+            for meter in station_data.get("devices", {}).get("meters", []):
+                entities.extend(
+                    [
+                        HoymilesDeviceAttributeSensor(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            "meters",
+                            meter,
+                            "location",
+                            "Meter Location",
+                            "location",
+                            build_meter_device_info,
+                            value_transform=lambda value: METER_LOCATION_NAMES.get(value, str(value)),
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                        ),
+                        HoymilesDeviceAttributeSensor(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            "meters",
+                            meter,
+                            "ct_gain",
+                            "Meter CT Gain",
+                            "ct_gain",
+                            build_meter_device_info,
+                            value_transform=safe_float_convert,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                        ),
+                    ]
+                )
+
+            for dtu in station_data.get("devices", {}).get("dtus", []):
+                entities.extend(
+                    [
+                        HoymilesDeviceAttributeSensor(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            "dtus",
+                            dtu,
+                            "serial",
+                            "DTU Serial",
+                            "sn",
+                            build_dtu_device_info,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                            enabled_default=False,
+                        ),
+                        HoymilesDeviceAttributeSensor(
+                            coordinator,
+                            station_id,
+                            station_name,
+                            "dtus",
+                            dtu,
+                            "device_type",
+                            "DTU Device Type",
+                            "type",
+                            build_dtu_device_info,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                        ),
+                    ]
+                )
+
+        return entities
+
+    register_discovery(coordinator, entry, async_add_entities, build_entities)
 
 
 class HoymilesBaseSensor(CoordinatorEntity, SensorEntity):
@@ -950,10 +964,16 @@ class HoymilesAggregateSensor(HoymilesBaseSensor):
         """Return if entity is available."""
         if not self.coordinator.last_update_success:
             return False
+        station_data = self._get_station_data()
+        if (
+            station_data.get("telemetry_available") is False
+            and self.entity_description.key not in _NON_TELEMETRY_SENSOR_KEYS
+        ):
+            return False
         available_fn = self.entity_description.available_fn or self.entity_description.exists_fn
         if available_fn:
-            return available_fn(self._get_station_data())
-        return bool(self._get_station_data())
+            return available_fn(station_data)
+        return bool(station_data)
 
 
 class HoymilesBatteryModeSensor(HoymilesBaseSensor):

--- a/custom_components/hoymiles_cloud/sensor.py
+++ b/custom_components/hoymiles_cloud/sensor.py
@@ -36,6 +36,7 @@ from .data import (
     discover_pv_channels,
     get_allowed_battery_modes,
     get_energy_flow_value,
+    get_ev_charger_power,
     get_indicator_value,
     get_mode_settings,
     get_pv_indicator_value,
@@ -43,6 +44,7 @@ from .data import (
     get_signed_battery_power,
     is_invalid_total_increasing,
     get_supported_modes,
+    has_ev_charger,
     is_battery_charging,
 )
 from .device import (
@@ -189,6 +191,9 @@ class HoymilesSensorDescription(SensorEntityDescription):
 
     value_fn: Callable[[dict[str, Any]], StateType] | None = None
     exists_fn: Callable[[dict[str, Any]], bool] | None = None
+    # Defaults to ``exists_fn``. Set it when an entity should be created
+    # only under a narrow condition but must stay available afterwards.
+    available_fn: Callable[[dict[str, Any]], bool] | None = None
     device_info_fn: Callable[[str, str, dict[str, Any]], dict[str, Any]] | None = None
 
 
@@ -461,8 +466,9 @@ STATION_SENSORS: list[HoymilesSensorDescription] = [
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        exists_fn=lambda data: safe_float_convert(get_reflux_data(data).get("pile_power")) is not None,
-        value_fn=lambda data: safe_float_convert(get_reflux_data(data).get("pile_power")),
+        exists_fn=has_ev_charger,
+        available_fn=lambda data: safe_float_convert(get_reflux_data(data).get("pile_power")) is not None,
+        value_fn=get_ev_charger_power,
     ),
     HoymilesSensorDescription(
         key="self_consumption_rate",
@@ -944,8 +950,9 @@ class HoymilesAggregateSensor(HoymilesBaseSensor):
         """Return if entity is available."""
         if not self.coordinator.last_update_success:
             return False
-        if self.entity_description.exists_fn:
-            return self.entity_description.exists_fn(self._get_station_data())
+        available_fn = self.entity_description.available_fn or self.entity_description.exists_fn
+        if available_fn:
+            return available_fn(self._get_station_data())
         return bool(self._get_station_data())
 
 

--- a/custom_components/hoymiles_cloud/storage.py
+++ b/custom_components/hoymiles_cloud/storage.py
@@ -1,0 +1,23 @@
+"""Entry-scoped storage helpers, importable without Home Assistant."""
+
+from copy import deepcopy
+from typing import Any
+
+
+def entry_storage_key(base_key: str, entry_id: str) -> str:
+    """Give each config entry an independent Store file."""
+    return f"{base_key}_{entry_id}"
+
+
+def migrate_legacy_stations(
+    legacy: dict[str, Any] | None, station_ids: set[str]
+) -> dict[str, Any]:
+    """Copy only this entry's stations; leave the shared legacy file untouched."""
+    source = (legacy or {}).get("stations", {})
+    if not isinstance(source, dict):
+        return {"stations": {}}
+    return {"stations": {
+        station_id: deepcopy(source[station_id])
+        for station_id in station_ids
+        if station_id in source and isinstance(source[station_id], dict)
+    }}

--- a/custom_components/hoymiles_cloud/switch.py
+++ b/custom_components/hoymiles_cloud/switch.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+# Coordinator polls and API writes manage their own scheduling.
+PARALLEL_UPDATES = 0
+
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
@@ -11,6 +14,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
+from .discovery import invalidate_control_cache, register_discovery
 from .const import DOMAIN
 from .data import relay_settings_readable, relay_settings_writable, relay_settings_enabled
 from .device import build_station_device_info
@@ -30,16 +34,20 @@ async def async_setup_entry(
     """Set up Hoymiles Cloud switches."""
     runtime_data = hass.data[DOMAIN][entry.entry_id]
     coordinator = runtime_data["coordinator"]
+    coordinator.invalidate_control_cache = runtime_data["invalidate_control_cache"]
     stations = runtime_data["stations"]
     api = runtime_data["api"]
 
-    entities: list[SwitchEntity] = []
-    for station_id, station_name in stations.items():
-        station_data = get_station_data(coordinator, station_id)
-        if relay_settings_readable(station_data.get("relay_settings")):
-            entities.append(HoymilesRelaySwitch(coordinator, api, station_id, station_name))
+    def build_entities() -> list:
+        entities: list[SwitchEntity] = []
+        for station_id, station_name in stations.items():
+            station_data = get_station_data(coordinator, station_id)
+            if relay_settings_readable(station_data.get("relay_settings")):
+                entities.append(HoymilesRelaySwitch(coordinator, api, station_id, station_name))
 
-    async_add_entities(entities)
+        return entities
+
+    register_discovery(coordinator, entry, async_add_entities, build_entities)
 
 
 class HoymilesRelaySwitch(CoordinatorEntity, SwitchEntity):
@@ -77,11 +85,13 @@ class HoymilesRelaySwitch(CoordinatorEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable relay automation."""
         if await self._api.set_relay_enabled(self._station_id, True):
+            invalidate_control_cache(self.coordinator, self._station_id)
             await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable relay automation."""
         if await self._api.set_relay_enabled(self._station_id, False):
+            invalidate_control_cache(self.coordinator, self._station_id)
             await self.coordinator.async_request_refresh()
 
     @property

--- a/custom_components/hoymiles_cloud/text.py
+++ b/custom_components/hoymiles_cloud/text.py
@@ -1,6 +1,9 @@
 """Text entities for the Hoymiles schedule editor."""
 from __future__ import annotations
 
+# Coordinator polls and API writes manage their own scheduling.
+PARALLEL_UPDATES = 0
+
 from typing import Any
 
 from homeassistant.components.text import TextEntity
@@ -10,6 +13,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
+from .discovery import register_discovery
 from .const import BATTERY_MODE_ECONOMY, BATTERY_MODE_TIME_OF_USE, DOMAIN
 from .schedule_editor import (
     build_device_info,
@@ -34,105 +38,108 @@ async def async_setup_entry(
     stations = runtime_data["stations"]
     set_schedule_editor_field = runtime_data["set_schedule_editor_field"]
 
-    entities = []
-    for station_id, station_name in stations.items():
-        station_data = coordinator.data.get(station_id, {}) if coordinator.data else {}
-        if not station_data.get("schedule_editor", {}).get("available_modes"):
-            continue
-        entities.extend(
-            [
-                HoymilesScheduleTextEntity(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    set_schedule_editor_field,
-                    BATTERY_MODE_TIME_OF_USE,
-                    "time_of_use_charge_start",
-                    "Time of Use Charge Start",
-                    _tou_period_path,
-                    "cs_time",
-                ),
-                HoymilesScheduleTextEntity(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    set_schedule_editor_field,
-                    BATTERY_MODE_TIME_OF_USE,
-                    "time_of_use_charge_end",
-                    "Time of Use Charge End",
-                    _tou_period_path,
-                    "ce_time",
-                ),
-                HoymilesScheduleTextEntity(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    set_schedule_editor_field,
-                    BATTERY_MODE_TIME_OF_USE,
-                    "time_of_use_discharge_start",
-                    "Time of Use Discharge Start",
-                    _tou_period_path,
-                    "dcs_time",
-                ),
-                HoymilesScheduleTextEntity(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    set_schedule_editor_field,
-                    BATTERY_MODE_TIME_OF_USE,
-                    "time_of_use_discharge_end",
-                    "Time of Use Discharge End",
-                    _tou_period_path,
-                    "dce_time",
-                ),
-                HoymilesScheduleTextEntity(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    set_schedule_editor_field,
-                    BATTERY_MODE_ECONOMY,
-                    "economy_start_date",
-                    "Economy Start Date",
-                    _economy_window_path,
-                    "start_date",
-                ),
-                HoymilesScheduleTextEntity(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    set_schedule_editor_field,
-                    BATTERY_MODE_ECONOMY,
-                    "economy_end_date",
-                    "Economy End Date",
-                    _economy_window_path,
-                    "end_date",
-                ),
-                HoymilesScheduleTextEntity(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    set_schedule_editor_field,
-                    BATTERY_MODE_ECONOMY,
-                    "economy_duration_start",
-                    "Economy Duration Start",
-                    _economy_duration_path,
-                    "start_time",
-                ),
-                HoymilesScheduleTextEntity(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    set_schedule_editor_field,
-                    BATTERY_MODE_ECONOMY,
-                    "economy_duration_end",
-                    "Economy Duration End",
-                    _economy_duration_path,
-                    "end_time",
-                ),
-            ]
-        )
+    def build_entities() -> list:
+        entities = []
+        for station_id, station_name in stations.items():
+            station_data = coordinator.data.get(station_id, {}) if coordinator.data else {}
+            if not station_data.get("schedule_editor", {}).get("available_modes"):
+                continue
+            entities.extend(
+                [
+                    HoymilesScheduleTextEntity(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        set_schedule_editor_field,
+                        BATTERY_MODE_TIME_OF_USE,
+                        "time_of_use_charge_start",
+                        "Time of Use Charge Start",
+                        _tou_period_path,
+                        "cs_time",
+                    ),
+                    HoymilesScheduleTextEntity(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        set_schedule_editor_field,
+                        BATTERY_MODE_TIME_OF_USE,
+                        "time_of_use_charge_end",
+                        "Time of Use Charge End",
+                        _tou_period_path,
+                        "ce_time",
+                    ),
+                    HoymilesScheduleTextEntity(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        set_schedule_editor_field,
+                        BATTERY_MODE_TIME_OF_USE,
+                        "time_of_use_discharge_start",
+                        "Time of Use Discharge Start",
+                        _tou_period_path,
+                        "dcs_time",
+                    ),
+                    HoymilesScheduleTextEntity(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        set_schedule_editor_field,
+                        BATTERY_MODE_TIME_OF_USE,
+                        "time_of_use_discharge_end",
+                        "Time of Use Discharge End",
+                        _tou_period_path,
+                        "dce_time",
+                    ),
+                    HoymilesScheduleTextEntity(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        set_schedule_editor_field,
+                        BATTERY_MODE_ECONOMY,
+                        "economy_start_date",
+                        "Economy Start Date",
+                        _economy_window_path,
+                        "start_date",
+                    ),
+                    HoymilesScheduleTextEntity(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        set_schedule_editor_field,
+                        BATTERY_MODE_ECONOMY,
+                        "economy_end_date",
+                        "Economy End Date",
+                        _economy_window_path,
+                        "end_date",
+                    ),
+                    HoymilesScheduleTextEntity(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        set_schedule_editor_field,
+                        BATTERY_MODE_ECONOMY,
+                        "economy_duration_start",
+                        "Economy Duration Start",
+                        _economy_duration_path,
+                        "start_time",
+                    ),
+                    HoymilesScheduleTextEntity(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        set_schedule_editor_field,
+                        BATTERY_MODE_ECONOMY,
+                        "economy_duration_end",
+                        "Economy Duration End",
+                        _economy_duration_path,
+                        "end_time",
+                    ),
+                ]
+            )
 
-    async_add_entities(entities)
+        return entities
+
+    register_discovery(coordinator, entry, async_add_entities, build_entities)
 
 
 def _tou_period_path(draft: dict[str, Any]) -> tuple[Any, ...]:

--- a/custom_components/hoymiles_cloud/translations/en.json
+++ b/custom_components/hoymiles_cloud/translations/en.json
@@ -14,13 +14,25 @@
       "confirm": {
         "title": "Confirm Stations",
         "description": "Authentication succeeded. The following stations were discovered: {stations}"
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate Hoymiles Cloud",
+        "description": "Enter updated credentials for the same Hoymiles account. Your stations, entities, and options will be retained.",
+        "data": {
+          "username": "Username (Email)",
+          "password": "Password",
+          "auth_mode": "Authentication mode",
+          "app_version": "Override app version (optional)"
+        }
       }
     },
     "progress": {
       "confirm": "Verifying credentials and discovering stations"
     },
     "abort": {
-      "already_configured": "Account already configured"
+      "already_configured": "Account already configured",
+      "reauth_successful": "Reauthentication was successful",
+      "unknown": "The configuration entry is no longer available"
     },
     "error": {
       "cannot_connect": "Failed to connect to Hoymiles Cloud",
@@ -29,7 +41,9 @@
       "s_miles_home_required": "This S-Miles Home account could not be authenticated. Make sure you are on the latest version and try the 'S-Miles Home' authentication mode. If it still fails, please report it on the integration's issue tracker.",
       "no_stations": "No stations found for this account",
       "no_accessible_stations": "Authentication succeeded, but no accessible stations were returned for this account",
-      "unknown": "Unexpected error"
+      "unknown": "Unexpected error",
+      "account_mismatch": "Use the same account as this integration entry",
+      "already_configured": "This account is already configured"
     }
   },
   "selector": {

--- a/docs/hoymiles-module-data-api.md
+++ b/docs/hoymiles-module-data-api.md
@@ -66,6 +66,54 @@ Assistant and the cloud) counts as current, and a response without a usable
 `x_axis` keeps its raw sample so hardware variants that omit the labels still
 work.
 
+## Determining which channels exist
+
+The `port` in `mi_list` is a **per-microinverter** port number, while the PV
+indicators feed exposes **station-level** channel numbers (`1_pv_v`, `2_pv_p`,
+…). Nothing we fetch states how one maps to the other, so the fallback only
+runs where `channel N == port N` is sound — a station with exactly one
+microinverter (issue #56).
+
+The channel list itself cannot come from the indicators feed alone. On some
+firmware a port is omitted from the feed entirely rather than reported with a
+placeholder value, so there is no key to discover and nothing to fill. Observed
+on an HMS-800-2WB (DTU `V01.03.04`, microinverter `V01.03.01`, issue #39):
+
+```json
+"microinverters": {
+  "33820520": {
+    "init_hard_no": "HMS-800-2WB",
+    "rule": { "dev_type": 3, "port": 2 }
+  }
+},
+"pv_indicators": {
+  "pv_total": 1,
+  "list": [
+    { "key": "pv_p_total", "val": 26.1 },
+    { "key": "1_pv_v", "val": 32.7 },
+    { "key": "1_pv_i", "val": 0.8 },
+    { "key": "1_pv_p", "val": 26.1 }
+  ]
+}
+```
+
+`rule.port` in the microinverter detail payload (`/dev/micro/find`, stored
+wholesale in `microinverters[id]`) is the authoritative port count — here `2`,
+against a feed advertising one channel and a `pv_total` of `1`. Note that
+`pv_total` agrees with the truncated feed, not with the hardware, so it is not
+usable for this.
+
+`data.expected_pv_channels()` therefore derives `1..rule.port` from that
+payload, and `data.seed_missing_pv_channels()` inserts placeholder `v`/`i`/`p`
+entries for any channel the feed omits. The omitted channel then looks like any
+other placeholder and is filled by the fallback above. A channel that cannot be
+filled stays unset and reads as unknown rather than borrowing another channel's
+value.
+
+Both functions return nothing for a multi-microinverter station: the mapping
+there is still unknown, and guessing it is the failure mode #53 introduced and
+had to revert.
+
 ## Polling cost
 
 The cloud refreshes plant telemetry only every ~5 minutes, so the coordinator

--- a/docs/release-1.3.1rc1.md
+++ b/docs/release-1.3.1rc1.md
@@ -1,0 +1,76 @@
+# 1.3.1rc1 — release candidate for 1.3.1
+
+This is a prerelease, based on v1.3.0, intended for installation testing before a
+stable 1.3.1 release. It retains the existing battery power sign convention and
+entity identifiers.
+
+## Changes
+
+- Integrate Claude's PV discovery fix from `79dd4fe` (PR #67). A single
+  microinverter's declared `rule.port` can seed missing PV channels for the
+  existing module-data fallback. Multi-device mappings are not guessed.
+- Integrate Claude's charger capability work from `cbf1628`, then replace its
+  legacy wattage fallback with signed burst telemetry. A numeric `pile_power`
+  value alone no longer establishes that a charger exists or is consuming power.
+- Obtain a signed stream URL through `get_sd_uri`, poll the observed EU burst
+  endpoint without account headers/cookies, and renew an expired URL once.
+  Publish charger `es.sp` only from valid recent telemetry, preserving real zero
+  and marking failed/missing data unavailable.
+- Retain v1.3.0's async battery write/status/readback flow and harden it further:
+  denied reads and unsupported modes block commands; unreadable readback cannot
+  claim a successful application or trigger a duplicate fallback write.
+- Run Argon2 password hashing off the event loop.
+- Isolate station refresh failures, bound request concurrency, and cache slower
+  inventory and control reads. Successful control changes invalidate the cache.
+- Discover optional entities after initial setup and remove discovery listeners
+  when unloading.
+- Stop deriving grid connection from the mere presence of a telemetry dictionary.
+  Without an explicit supported signal the state is unknown.
+- Move persistent drafts to per-entry storage, copying only that account's
+  stations from the legacy file without deleting it.
+- Add same-account reauthentication and additional diagnostics redaction.
+
+## Upgrade and rollback
+
+Extract `custom_components/hoymiles_cloud` from the candidate archive into your
+Home Assistant configuration's `custom_components` directory and restart.
+Existing entities keep their unique IDs. The charger sensor may change from a
+misleading number to unavailable when the account cannot supply live data.
+Automations should handle unavailable states.
+
+To roll back, restore v1.3.0's integration directory and restart. Legacy storage
+is retained, but edits made in the new per-entry draft store are not copied back
+into the old shared store. Use your configuration backup when preserving those
+edits matters.
+
+## Validation scope
+
+The standalone regression suite and an optional script against real Home
+Assistant validate local behavior with fake cloud responses. Exact results are
+recorded in the GitHub prerelease description after final checks. The public
+portal and issue #64 establish the observed endpoint shape; no authenticated
+hardware write or numerical comparison against the user's station was performed.
+
+Before promoting to stable, test a real station with a connected and disconnected
+EV charger, a battery mode/settings write and readback, token expiry, and an HA
+restart with multiple configured accounts.
+
+## Known limits
+
+- Burst URL validation currently accepts the observed `eurt.hoymiles.com` host.
+  Other regions require verified endpoint evidence.
+- Live polling follows the configured integration interval (60 seconds by
+  default); this does not promise the portal's ten-second refresh cadence.
+- Aggregate PV/grid/battery/load sensors keep their established source and sign
+  conventions. Compact burst fields are not substituted wholesale because their
+  meanings, especially load accounting, differ between payload families.
+- Temperature, AI mode 9 controls, complete alarm coverage, cloud history backfill,
+  and multi-microinverter port mappings remain outside this candidate.
+- This candidate does not claim Home Assistant Quality Scale certification or
+  comprehensive hardware compatibility.
+
+Related: [#39](https://github.com/Philra94/homeassistant-hoymiles-cloud/issues/39),
+[#56](https://github.com/Philra94/homeassistant-hoymiles-cloud/issues/56),
+[#59](https://github.com/Philra94/homeassistant-hoymiles-cloud/issues/59),
+[#64](https://github.com/Philra94/homeassistant-hoymiles-cloud/issues/64),
+[#67](https://github.com/Philra94/homeassistant-hoymiles-cloud/pull/67).

--- a/docs/release-1.3.1rc2.md
+++ b/docs/release-1.3.1rc2.md
@@ -1,0 +1,42 @@
+# 1.3.1rc2 — release candidate for 1.3.1
+
+RC2 fixes the missing Authorization header that caused RC1 burst requests to
+fail with HTTP 400 and prevented live charger telemetry from being obtained
+(issue #64). It includes the other changes from [RC1](release-1.3.1rc1.md).
+
+Burst requests now send the raw account token, with no Bearer prefix. The
+destination is validated before authentication, cookies remain isolated, and
+redirects remain disabled. Cached stream URLs also use a refreshed account
+token when needed. Regression tests enforce this corrected request contract.
+RC1's statement that burst requests need no account headers was incorrect.
+
+## Validation
+
+- 129 regression tests pass.
+- Home Assistant 2026.9.2 lifecycle smoke passes with fake cloud transport.
+- The patched API client independently fetched live hybrid data successfully
+  using its real authenticated request path and isolated burst session.
+
+A bounded read-only cloud test returned HTTP 400 without Authorization and four
+HTTP 200 responses with it. Authorized hybrid responses reported `con:1` and a
+10-second delay; timestamps advanced and power values changed. No Home Assistant
+installation, configuration, device setting or battery control was changed.
+Credentials, identifiers, signed URLs and raw responses are excluded.
+
+This validates the cloud request contract, not charger behavior in every state
+or end-to-end Home Assistant entity updates. Disconnected, idle and charging
+comparisons remain required before promotion to stable.
+
+## Known limits and installation
+
+Dedicated fast polling requested in #69 is not included. Burst requests still
+follow the configured integration interval, and station PV Power still uses the
+ordinary telemetry endpoint. HMS per-inverter `mis` and station `power` payloads
+need separate implementation and hardware validation. The observed hybrid
+10-second cadence must not be advertised as universal 2-second updates.
+
+Select `v1.3.1rc2` with beta versions enabled in HACS, or replace
+`custom_components/hoymiles_cloud` using the attached archive, then restart
+Home Assistant. Keep a configuration backup. Existing entity identifiers are
+unchanged. RC1 remains immutable; rollback and draft-storage considerations in
+its notes still apply. Latest stable remains v1.3.0.

--- a/resources/home-assistant-test/README.md
+++ b/resources/home-assistant-test/README.md
@@ -3,6 +3,21 @@
 This directory contains a disposable Home Assistant setup for validating the
 custom component in this repository against the real UI.
 
+## Automated lifecycle smoke check
+
+With Home Assistant 2026.9.2 and `argon2-cffi` installed in a disposable Python
+3.14 environment, run from the repository root:
+
+```bash
+python scripts/validate_homeassistant.py
+```
+
+This uses real Home Assistant coordinator, config-entry, and entity classes with
+fake cloud responses. It checks setup, late discovery, station failure isolation,
+reauthentication, and unloading without cloud credentials or hardware commands.
+It is separate from the HA-free `pytest -q` suite and runs in validation CI.
+It does not replace a real account's UI and hardware acceptance test.
+
 ## Start
 
 ```bash

--- a/scripts/validate_homeassistant.py
+++ b/scripts/validate_homeassistant.py
@@ -1,0 +1,225 @@
+"""Optional smoke check against an installed Home Assistant (no cloud requests).
+
+Run with an HA environment: python scripts/validate_homeassistant.py
+The ordinary pytest suite intentionally does not require Home Assistant.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import sys
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from homeassistant.config_entries import ConfigEntry, ConfigEntries, ConfigEntryState, current_entry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er, frame
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from custom_components.hoymiles_cloud import (  # noqa: E402
+    PLATFORMS,
+    async_setup_entry,
+    async_unload_entry,
+)
+from custom_components.hoymiles_cloud import config_flow  # noqa: E402
+from custom_components.hoymiles_cloud.const import DOMAIN  # noqa: E402
+from custom_components.hoymiles_cloud.hoymiles_api import LiveDataAuthError  # noqa: E402
+
+
+class FakeAPI:
+    """Deterministic transport stub used with real HA coordinator and entities."""
+
+    fail_station: str | None = None
+    auth_failure = False
+    include_pv = False
+    last_auth_status = "1"
+    last_auth_message = "ok"
+    last_auth_attempt_summary = "fake"
+    last_auth_error_key = None
+
+    def __init__(self, session, username, password):
+        self.username = username
+        self.password = password
+
+    def configure_auth(self, **kwargs):
+        pass
+
+    async def authenticate(self):
+        return self.password == "good"
+
+    def is_token_expired(self):
+        return False
+
+    async def get_stations(self):
+        return {"station-a": "A", "station-b": "B"}
+
+    async def get_real_time_data(self, station_id):
+        if station_id == self.fail_station:
+            raise RuntimeError("fake telemetry outage")
+        return {"pv_power": 100}
+
+    async def get_live_data(self, station_id):
+        if self.auth_failure:
+            raise LiveDataAuthError("fake authorization failure")
+        if station_id == self.fail_station:
+            raise RuntimeError("fake burst outage")
+        return {"es": {"sp": 0}, "icon": {"pile": 1}}
+
+    async def get_pv_indicators(self, station_id):
+        if self.include_pv:
+            return {"list": [{"key": "1_pv_p", "val": 80},
+                             {"key": "1_pv_v", "val": 30},
+                             {"key": "1_pv_i", "val": 2}]}
+        return {}
+
+    async def set_battery_mode_settings(self, station_id, mode, settings, *, merge=True):
+        return True
+
+    def __getattr__(self, name):
+        async def empty(*args, **kwargs):
+            return [] if name.startswith("get_") and name[4:] in {
+                "dtus", "inverters", "batteries", "meters"
+            } else {}
+        return empty
+
+
+def make_entry() -> ConfigEntry:
+    return ConfigEntry(
+        data={"username": "smoke@example.test", "password": "good"},
+        discovery_keys={}, domain=DOMAIN, minor_version=1, options={},
+        source="user", title="Smoke", unique_id="smoke@example.test", version=1,
+        subentries_data=[],
+        state=ConfigEntryState.SETUP_IN_PROGRESS,
+    )
+
+
+async def main() -> None:
+    with TemporaryDirectory(prefix="hoymiles-ha-smoke-") as config_dir:
+        hass = HomeAssistant(config_dir)
+        hass.config_entries = ConfigEntries(hass, {})
+        frame.async_setup(hass)
+        hass.data[dr.DATA_REGISTRY] = dr.DeviceRegistry(hass)
+        await dr.async_get(hass).async_load(load_empty=True)
+        await er.async_get(hass).async_load(load_empty=True)
+        entry = make_entry()
+        # Register without async_add's automatic integration loader setup; this
+        # script drives the integration entry directly under patched transport.
+        hass.config_entries._entries[entry.entry_id] = entry
+        entities: dict[str, list] = {}
+        reauth_requests: list[str] = []
+
+        def reauth(_entry, _hass):
+            reauth_requests.append(entry.entry_id)
+
+        async def forward(_manager, _entry, platforms):
+            for platform in platforms:
+                module = __import__(f"custom_components.hoymiles_cloud.{platform.value}", fromlist=["async_setup_entry"])
+                entities[platform.value] = []
+                await module.async_setup_entry(
+                    hass, entry, lambda additions, update_before_add=False, key=platform.value: entities[key].extend(additions)
+                )
+
+        async def unload(_manager, _entry, platforms):
+            return True
+
+        with (
+            patch("custom_components.hoymiles_cloud.HoymilesAPI", FakeAPI),
+            patch("custom_components.hoymiles_cloud.async_get_clientsession", return_value=object()),
+            patch.object(ConfigEntries, "async_forward_entry_setups", forward),
+            patch.object(ConfigEntries, "async_unload_platforms", unload),
+            patch.object(ConfigEntry, "async_start_reauth_if_available", reauth),
+        ):
+            context_token = current_entry.set(entry)
+            try:
+                assert await async_setup_entry(hass, entry)
+            finally:
+                current_entry.reset(context_token)
+            coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+            assert coordinator.data["station-a"]["telemetry_available"]
+            assert set(entities) == {platform.value for platform in PLATFORMS}
+            base_counts = {key: len(value) for key, value in entities.items()}
+            assert entities["sensor"], "real sensor entities were not constructed"
+
+            FakeAPI.include_pv = True
+            await coordinator.async_refresh()
+            await hass.async_block_till_done()
+            assert len(entities["sensor"]) > base_counts["sensor"], "late PV discovery failed"
+            once = len(entities["sensor"])
+            await coordinator.async_refresh()
+            await hass.async_block_till_done()
+            assert len(entities["sensor"]) == once, "discovery duplicated entities"
+
+            # A successful write followed by an unreadable settings response
+            # must retain the user's draft even if the old coordinator data
+            # had readable settings. This checks an awaited refresh occurs.
+            runtime = hass.data[DOMAIN][entry.entry_id]
+            station = coordinator.data["station-a"]
+            station["battery_settings"] = {"readable": True}
+            station["schedule_editor"] = {
+                "modes": {8: {"validation_errors": [], "draft": {"periods": []}}}
+            }
+            draft_store = runtime["stored_data"]["stations"]["station-a"]["schedule_editor"]
+            draft_store["modes"]["8"] = {"periods": []}
+            try:
+                await runtime["apply_schedule_draft"]("station-a", 8)
+            except HomeAssistantError as err:
+                assert "draft was retained" in str(err)
+            else:
+                raise AssertionError("schedule draft cleared without fresh settings")
+            assert "8" in draft_store["modes"]
+
+            FakeAPI.fail_station = "station-b"
+            await coordinator.async_refresh()
+            assert not coordinator.data["station-b"]["telemetry_available"]
+            assert coordinator.data["station-b"]["live_data"] == {}
+            assert coordinator.data["station-a"]["telemetry_available"]
+            FakeAPI.fail_station = None
+
+            FakeAPI.auth_failure = True
+            await coordinator.async_refresh()
+            assert not coordinator.last_update_success, "auth failure did not fail the coordinator"
+            assert reauth_requests, "HA did not request reauthentication"
+            FakeAPI.auth_failure = False
+
+            assert await async_unload_entry(hass, entry)
+            assert entry.entry_id not in hass.data[DOMAIN]
+
+        reloads: list[str] = []
+
+        async def reload(_manager, entry_id):
+            reloads.append(entry_id)
+            return True
+
+        with (
+            patch("custom_components.hoymiles_cloud.config_flow.HoymilesAPI", FakeAPI),
+            patch("custom_components.hoymiles_cloud.config_flow.async_get_clientsession", return_value=object()),
+            patch.object(ConfigEntries, "async_reload", reload),
+        ):
+            flow = config_flow.ConfigFlow()
+            flow.hass = hass
+            flow.context = {"entry_id": entry.entry_id}
+            form = await flow.async_step_reauth(dict(entry.data))
+            assert form["type"] == "form"
+            mismatch = await flow.async_step_reauth_confirm({
+                "username": "different@example.test", "password": "good",
+                "auth_mode": "auto", "app_version": "",
+            })
+            assert mismatch["errors"]["base"] == "account_mismatch"
+            assert not reloads
+            success = await flow.async_step_reauth_confirm({
+                "username": "smoke@example.test", "password": "good",
+                "auth_mode": "auto", "app_version": "",
+            })
+            assert success["type"] == "abort" and success["reason"] == "reauth_successful"
+            assert reloads == [entry.entry_id], "reauth should reload exactly once"
+
+        await hass.async_stop()
+    print("Home Assistant lifecycle smoke passed")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -18,7 +18,9 @@ get_allowed_battery_modes = data_module.get_allowed_battery_modes
 get_battery_flow_direction = data_module.get_battery_flow_direction
 get_schedule_modes = data_module.get_schedule_modes
 get_microinverter_port_count = data_module.get_microinverter_port_count
+get_ev_charger_power = data_module.get_ev_charger_power
 get_signed_battery_power = data_module.get_signed_battery_power
+has_ev_charger = data_module.has_ev_charger
 is_battery_charging = data_module.is_battery_charging
 latest_module_values = data_module.latest_module_values
 merge_missing_pv_channel_values = data_module.merge_missing_pv_channel_values
@@ -702,3 +704,67 @@ def test_non_numeric_values_are_not_rejected() -> None:
     assert data_module.is_invalid_total_increasing(None, True) is False
     assert data_module.is_invalid_total_increasing("-5", True) is False
     assert data_module.is_invalid_total_increasing(False, True) is False
+
+
+def _station_with_reflux(**reflux: object) -> dict:
+    """Build a station payload carrying the given reflux fields."""
+    return {"real_time_data": {"reflux_station_data": reflux}}
+
+
+def test_ev_charger_hidden_when_no_pile_is_advertised() -> None:
+    """A station without a charging pile must not get the sensor.
+
+    pile_power is emitted regardless of whether a charger exists, and on a
+    station without one it mirrored PV power (issue #64). The icon flags are
+    what the vendor app gates the charging-pile node on.
+    """
+    station = _station_with_reflux(pile_power="742", icon_plug=0, icon_ai_plug=0)
+
+    assert has_ev_charger(station) is False
+
+
+def test_ev_charger_power_reports_zero_while_no_pile_is_connected() -> None:
+    """The mirrored value is replaced by 0 W, not published or dropped."""
+    station = _station_with_reflux(pile_power="742", icon_plug=0, icon_ai_plug=0)
+
+    assert get_ev_charger_power(station) == 0.0
+
+
+def test_ev_charger_exposed_when_a_pile_is_advertised() -> None:
+    """Either icon flag is enough to treat pile_power as charger telemetry."""
+    plain = _station_with_reflux(pile_power="3600", icon_plug=1, icon_ai_plug=0)
+    ai = _station_with_reflux(pile_power="3600", icon_plug="0", icon_ai_plug="1")
+
+    assert has_ev_charger(plain) is True
+    assert get_ev_charger_power(plain) == 3600.0
+    assert has_ev_charger(ai) is True
+    assert get_ev_charger_power(ai) == 3600.0
+
+
+def test_ev_charger_keeps_legacy_behaviour_without_icon_flags() -> None:
+    """Payloads that carry neither flag must not lose the entity."""
+    station = _station_with_reflux(pile_power="3600")
+
+    assert has_ev_charger(station) is True
+    assert get_ev_charger_power(station) == 3600.0
+
+
+def test_ev_charger_absent_without_pile_power() -> None:
+    """No pile_power at all means there is nothing to report."""
+    assert has_ev_charger(_station_with_reflux(icon_plug=1)) is False
+    assert has_ev_charger(_station_with_reflux(pile_power="-")) is False
+    assert get_ev_charger_power(_station_with_reflux()) is None
+
+
+def test_capabilities_report_ev_charger_availability() -> None:
+    """Diagnostics should show whether the charger sensor was created."""
+    real_time_data = {"reflux_station_data": {"pile_power": "742", "icon_plug": 0}}
+
+    capabilities = build_station_capabilities(
+        real_time_data=real_time_data,
+        pv_indicators={},
+        battery_settings={},
+        microinverters_data={},
+    )
+
+    assert capabilities["ev_charger_available"] is False

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -724,34 +724,34 @@ def test_ev_charger_hidden_when_no_pile_is_advertised() -> None:
 
 
 def test_ev_charger_power_reports_zero_while_no_pile_is_connected() -> None:
-    """The mirrored value is replaced by 0 W, not published or dropped."""
+    """The mirrored legacy value is never interpreted as a real zero."""
     station = _station_with_reflux(pile_power="742", icon_plug=0, icon_ai_plug=0)
 
-    assert get_ev_charger_power(station) == 0.0
+    assert get_ev_charger_power(station) is None
 
 
 def test_ev_charger_exposed_when_a_pile_is_advertised() -> None:
-    """Either icon flag is enough to treat pile_power as charger telemetry."""
+    """Icon flags expose the entity but do not validate legacy pile_power."""
     plain = _station_with_reflux(pile_power="3600", icon_plug=1, icon_ai_plug=0)
     ai = _station_with_reflux(pile_power="3600", icon_plug="0", icon_ai_plug="1")
 
     assert has_ev_charger(plain) is True
-    assert get_ev_charger_power(plain) == 3600.0
+    assert get_ev_charger_power(plain) is None
     assert has_ev_charger(ai) is True
-    assert get_ev_charger_power(ai) == 3600.0
+    assert get_ev_charger_power(ai) is None
 
 
 def test_ev_charger_keeps_legacy_behaviour_without_icon_flags() -> None:
-    """Payloads that carry neither flag must not lose the entity."""
+    """A legacy pile_power alone cannot establish charger support."""
     station = _station_with_reflux(pile_power="3600")
 
-    assert has_ev_charger(station) is True
-    assert get_ev_charger_power(station) == 3600.0
+    assert has_ev_charger(station) is False
+    assert get_ev_charger_power(station) is None
 
 
 def test_ev_charger_absent_without_pile_power() -> None:
-    """No pile_power at all means there is nothing to report."""
-    assert has_ev_charger(_station_with_reflux(icon_plug=1)) is False
+    """An advertised pile can have temporarily missing live power."""
+    assert has_ev_charger(_station_with_reflux(icon_plug=1)) is True
     assert has_ev_charger(_station_with_reflux(pile_power="-")) is False
     assert get_ev_charger_power(_station_with_reflux()) is None
 
@@ -768,3 +768,55 @@ def test_capabilities_report_ev_charger_availability() -> None:
     )
 
     assert capabilities["ev_charger_available"] is False
+
+
+def test_burst_charger_power_uses_es_sp_with_fetch_freshness() -> None:
+    from datetime import datetime, timezone
+
+    now = datetime(2026, 9, 12, 12, 0, tzinfo=timezone.utc)
+    station = _station_with_reflux(pile_power="742", icon_plug=1)
+    station["live_data"] = {"es": {"pp": 742, "sp": 0}, "t": "station local", "dly": 10000}
+    station["live_fetched_at"] = now.timestamp()
+    assert has_ev_charger(station) is True
+    assert get_ev_charger_power(station, now=now) == 0.0
+    station["live_data"]["es"]["sp"] = 3600
+    assert get_ev_charger_power(station, now=now) == 3600.0
+    station["live_fetched_at"] -= 91
+    assert get_ev_charger_power(station, now=now) is None
+    station["live_fetched_at"] = None
+    assert get_ev_charger_power(station, now=now) is None
+
+
+def test_grid_connected_needs_explicit_signal() -> None:
+    assert data_module.get_grid_connected(_station_with_reflux(grid_power=123)) is None
+    assert data_module.get_grid_connected(_station_with_reflux(grid_connected=0)) is False
+    assert data_module.get_grid_connected(_station_with_reflux(grid_connected=1)) is True
+
+
+def test_live_icon_overrides_legacy_flags_and_rejects_invalid_power() -> None:
+    from datetime import datetime, timezone
+
+    now = datetime(2026, 9, 12, 12, tzinfo=timezone.utc)
+    station = _station_with_reflux(icon_plug=0, pile_power=742)
+    station.update(live_data={"icon": {"pile": 1}, "es": {"sp": 2500}}, live_fetched_at=now.timestamp())
+    assert has_ev_charger(station) is True
+    assert get_ev_charger_power(station, now=now) == 2500
+    for value in (-1, float("nan"), float("inf"), "-"):
+        station["live_data"]["es"]["sp"] = value
+        assert get_ev_charger_power(station, now=now) is None
+    station["live_data"]["icon"]["pile"] = 0
+    assert has_ev_charger(station) is False
+    station["live_data"]["es"]["sp"] = 2500
+    assert get_ev_charger_power(station, now=now) is None
+    station["live_data"]["es"]["sp"] = 0
+    assert get_ev_charger_power(station, now=now) is None
+
+
+def test_live_freshness_respects_configured_scan_interval() -> None:
+    from datetime import datetime, timezone
+
+    now = datetime(2026, 9, 12, 12, tzinfo=timezone.utc)
+    station = {"live_data": {"icon": {"pile": 1}, "es": {"sp": 50}}, "live_fetched_at": now.timestamp() - 300, "live_max_age": 600}
+    assert get_ev_charger_power(station, now=now) == 50
+    station["live_fetched_at"] = now.timestamp() - 601
+    assert get_ev_charger_power(station, now=now) is None

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -12,15 +12,18 @@ build_schedule_editor_state = data_module.build_schedule_editor_state
 build_schedule_payload_from_draft = data_module.build_schedule_payload_from_draft
 build_station_capabilities = data_module.build_station_capabilities
 discover_pv_channels = data_module.discover_pv_channels
+expected_pv_channels = data_module.expected_pv_channels
 find_placeholder_pv_channels = data_module.find_placeholder_pv_channels
 get_allowed_battery_modes = data_module.get_allowed_battery_modes
 get_battery_flow_direction = data_module.get_battery_flow_direction
 get_schedule_modes = data_module.get_schedule_modes
+get_microinverter_port_count = data_module.get_microinverter_port_count
 get_signed_battery_power = data_module.get_signed_battery_power
 is_battery_charging = data_module.is_battery_charging
 latest_module_values = data_module.latest_module_values
 merge_missing_pv_channel_values = data_module.merge_missing_pv_channel_values
 relay_settings_enabled = data_module.relay_settings_enabled
+seed_missing_pv_channels = data_module.seed_missing_pv_channels
 validate_schedule_draft = data_module.validate_schedule_draft
 
 
@@ -264,6 +267,126 @@ def test_find_placeholder_pv_channels_ignores_channels_with_real_values() -> Non
     }
 
     assert find_placeholder_pv_channels(pv_indicators) == []
+
+
+# --- Port-count derived channels (issue #39) ---------------------------------
+
+# An HMS-800-2WB reported by the issue: two physical ports, but the indicators
+# feed only ever returns keys for channel 1.
+HMS_800_2WB = {
+    "33820520": {
+        "id": 33820520,
+        "init_hard_no": "HMS-800-2WB",
+        "rule": {"dev_type": 3, "port": 2},
+    }
+}
+ONE_CHANNEL_FEED = {
+    "pv_total": 1,
+    "list": [
+        {"key": "pv_p_total", "val": 26.1},
+        {"key": "1_pv_v", "val": 32.7},
+        {"key": "1_pv_i", "val": 0.8},
+        {"key": "1_pv_p", "val": 26.1},
+    ],
+}
+
+
+def test_get_microinverter_port_count_reads_rule_port() -> None:
+    """The port count comes from rule.port in the detail payload."""
+    assert get_microinverter_port_count(HMS_800_2WB["33820520"]) == 2
+    assert get_microinverter_port_count({"rule": {"port": "4"}}) == 4
+
+
+@pytest.mark.parametrize(
+    "micro",
+    [
+        None,
+        {},
+        {"rule": None},
+        {"rule": {}},
+        {"rule": {"port": 0}},
+        {"rule": {"port": -1}},
+        {"rule": {"port": "two"}},
+        {"rule": {"port": True}},
+    ],
+)
+def test_get_microinverter_port_count_rejects_unusable_values(micro) -> None:
+    """Anything that is not a positive integer port count yields None."""
+    assert get_microinverter_port_count(micro) is None
+
+
+def test_expected_pv_channels_from_single_microinverter() -> None:
+    """A single two-port microinverter implies channels 1 and 2."""
+    assert expected_pv_channels(HMS_800_2WB) == [1, 2]
+
+
+def test_expected_pv_channels_declines_multi_microinverter_stations() -> None:
+    """Channel-to-port mapping is unknown with several devices (#56)."""
+    microinverters = {
+        "1": {"rule": {"port": 2}},
+        "2": {"rule": {"port": 2}},
+    }
+
+    assert expected_pv_channels(microinverters) == []
+
+
+def test_expected_pv_channels_without_port_count() -> None:
+    """A detail payload that states no port count claims nothing."""
+    assert expected_pv_channels({"1": {}}) == []
+    assert expected_pv_channels({}) == []
+    assert expected_pv_channels(None) == []
+
+
+def test_seed_missing_pv_channels_adds_the_omitted_channel() -> None:
+    """The channel the feed never reports becomes a fillable placeholder."""
+    seeded = seed_missing_pv_channels(ONE_CHANNEL_FEED, HMS_800_2WB)
+
+    assert discover_pv_channels(seeded) == [1, 2]
+    # Channel 1 keeps its real values; only channel 2 is a placeholder.
+    assert find_placeholder_pv_channels(seeded) == [2]
+
+
+def test_seed_missing_pv_channels_does_not_mutate_the_feed() -> None:
+    """Seeding returns a copy, leaving the fetched payload untouched."""
+    seed_missing_pv_channels(ONE_CHANNEL_FEED, HMS_800_2WB)
+
+    assert discover_pv_channels(ONE_CHANNEL_FEED) == [1]
+
+
+def test_seed_missing_pv_channels_is_a_noop_when_the_feed_is_complete() -> None:
+    """A feed already reporting every port is returned unchanged."""
+    feed = {
+        "list": [
+            {"key": "1_pv_p", "val": 26.1},
+            {"key": "2_pv_p", "val": 30.4},
+        ]
+    }
+
+    assert seed_missing_pv_channels(feed, HMS_800_2WB) is feed
+
+
+def test_seed_missing_pv_channels_ignores_an_empty_feed() -> None:
+    """A failed indicators fetch must not invent channels."""
+    assert seed_missing_pv_channels({}, HMS_800_2WB) == {}
+    assert seed_missing_pv_channels(None, HMS_800_2WB) == {}
+    assert seed_missing_pv_channels({"list": []}, HMS_800_2WB) == {"list": []}
+
+
+def test_seeded_channel_is_filled_by_module_data() -> None:
+    """End to end: an omitted channel is seeded and then filled (#39)."""
+    seeded = seed_missing_pv_channels(ONE_CHANNEL_FEED, HMS_800_2WB)
+
+    merged = merge_missing_pv_channel_values(
+        seeded,
+        {2: {"MODULE_V": 33.1, "MODULE_I": 0.9, "MODULE_POWER": 29.8}},
+    )
+
+    values = {item["key"]: item["val"] for item in merged["list"]}
+    assert values["2_pv_v"] == 33.1
+    assert values["2_pv_i"] == 0.9
+    assert values["2_pv_p"] == 29.8
+    # Channel 1's real readings are left alone.
+    assert values["1_pv_p"] == 26.1
 
 
 def test_merge_replaces_placeholder_channel_values() -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -56,8 +56,11 @@ def test_async_get_config_entry_diagnostics_redacts_sensitive_fields() -> None:
     )
 
     diagnostics = asyncio.run(diagnostics_module.async_get_config_entry_diagnostics(hass, entry))
+    assert diagnostics["config_entry"]["title"] == "**REDACTED**"
+    assert diagnostics["config_entry"]["entry_id"] == "**REDACTED**"
+    assert "123" not in diagnostics["coordinator"]["stations"]
 
-    station = diagnostics["coordinator"]["stations"]["123"]
+    station = diagnostics["coordinator"]["stations"]["station_1"]
     assert station["station_info"]["latitude"] == "**REDACTED**"
     assert station["device_inventory"]["batteries"][0]["sn"] == "**REDACTED**"
     assert station["battery_settings"]["mode_data"]["k_8"]["time"] == "<redacted>"
@@ -99,7 +102,7 @@ def test_device_inventory_includes_microinverters() -> None:
         }
     )
 
-    station = diagnostics["coordinator"]["stations"]["123"]
+    station = diagnostics["coordinator"]["stations"]["station_1"]
     inventory = station["device_inventory"]
     assert inventory["microinverters"]["42"]["model_no"] == "HMS-800-2T"
     assert station["device_counts"] == {
@@ -123,7 +126,7 @@ def test_station_summary_includes_telemetry_payloads() -> None:
         }
     )
 
-    station = diagnostics["coordinator"]["stations"]["123"]
+    station = diagnostics["coordinator"]["stations"]["station_1"]
     assert station["pv_indicators"]["list"][0]["key"] == "1_pv_v"
     assert station["real_time_data"]["reflux_station_data"]["bms_soc"] == 55
     assert station["grid_indicators"]["list"][0]["val"] == 12
@@ -150,7 +153,7 @@ def test_added_payloads_are_redacted() -> None:
         }
     )
 
-    station = diagnostics["coordinator"]["stations"]["123"]
+    station = diagnostics["coordinator"]["stations"]["station_1"]
     micro = station["device_inventory"]["microinverters"]["42"]
     assert micro["sn"] == "**REDACTED**"
     assert micro["dtu_sn"] == "**REDACTED**"

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,49 @@
+"""HA-free regression tests for late entity discovery."""
+
+from types import SimpleNamespace
+
+from tests.module_loader import load_integration_module
+
+
+def test_register_discovery_adds_late_entities_once_and_unloads() -> None:
+    discovery = load_integration_module("discovery")
+    listeners = []
+    unloads = []
+    added = []
+    entities = [SimpleNamespace(unique_id="station_pv1")]
+    coordinator = SimpleNamespace(async_add_listener=lambda callback: listeners.append(callback) or listeners.clear)
+    entry = SimpleNamespace(async_on_unload=unloads.append)
+
+    discovery.register_discovery(coordinator, entry, added.append, lambda: entities)
+    assert [[item.unique_id for item in batch] for batch in added] == [["station_pv1"]]
+    entities.append(SimpleNamespace(unique_id="station_pv2"))
+    listeners[0]()
+    listeners[0]()
+    assert [[item.unique_id for item in batch] for batch in added] == [["station_pv1"], ["station_pv2"]]
+    unloads[0]()
+    assert listeners == []
+
+
+def test_register_discovery_deduplicates_batch_and_retries_failed_add() -> None:
+    discovery = load_integration_module("discovery")
+    listeners = []
+    calls = []
+    entities = [SimpleNamespace(unique_id="initial")]
+    coordinator = SimpleNamespace(async_add_listener=lambda callback: listeners.append(callback) or (lambda: None))
+    entry = SimpleNamespace(async_on_unload=lambda callback: None)
+
+    def add(batch):
+        calls.append([entity.unique_id for entity in batch])
+        if len(calls) == 2:
+            raise RuntimeError("setup failed")
+
+    discovery.register_discovery(coordinator, entry, add, lambda: entities)
+    entities.extend([SimpleNamespace(unique_id="same"), SimpleNamespace(unique_id="same")])
+    try:
+        listeners[0]()
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("first late setup should fail")
+    listeners[0]()
+    assert calls == [["initial"], ["same"], ["same"]]

--- a/tests/test_hoymiles_api.py
+++ b/tests/test_hoymiles_api.py
@@ -808,8 +808,8 @@ def test_battery_write_retries_verification_while_the_plant_is_pending() -> None
     assert asyncio.run(api.set_battery_mode_settings("123", 1, {"reserve_soc": 11})) is True
 
 
-def test_battery_write_is_not_failed_by_a_permanently_unreadable_verification() -> None:
-    """If the settings never become readable, do not claim the write failed."""
+def test_battery_write_is_not_claimed_applied_when_verification_is_unreadable() -> None:
+    """An unverified write is inconclusive and must not be duplicated."""
     session = FakeSession(
         _read_job(1, "k_1", {"reserve_soc": 10})
         + _async_write_job()
@@ -819,4 +819,4 @@ def test_battery_write_is_not_failed_by_a_permanently_unreadable_verification() 
     api._token = "token"
     api._token_expires_at = 9999999999
 
-    assert asyncio.run(api.set_battery_mode("123", 1)) is True
+    assert asyncio.run(api.set_battery_mode("123", 1)) is False

--- a/tests/test_live_api.py
+++ b/tests/test_live_api.py
@@ -1,0 +1,147 @@
+"""Signed burst telemetry tests without contacting Hoymiles."""
+import asyncio
+
+import pytest
+
+from tests.module_loader import load_integration_module
+from tests.test_hoymiles_api import FakeSession
+
+module = load_integration_module("hoymiles_api")
+HoymilesAPI = module.HoymilesAPI
+SIGNED = "https://eurt.hoymiles.com/rds/api/0/burst/get?sig=private-value"
+
+
+def client(responses):
+    session = FakeSession(responses)
+    api = HoymilesAPI(session, "user@example.com", "secret")
+    api._token = "private-token"
+    api._token_expires_at = 9999999999
+    return api, session
+
+
+def test_live_burst_returns_raw_data_and_omits_auth_headers():
+    payload = {"es": {"pp": 1, "gp": 2, "bp": 3, "lp": 4, "sp": 5}, "soc": 66, "flow": [], "con": 1, "t": 123, "dly": 10000}
+    api, session = client([
+        {"status": "0", "data": SIGNED},
+        {"data": payload},
+        {"data": payload},
+    ])
+    assert asyncio.run(api.get_live_data("123")) == payload
+    assert asyncio.run(api.get_live_data("123")) == payload
+    assert len(session.requests) == 3
+    assert session.requests[0]["kwargs"]["json"] == {"sid": 123}
+    for request in session.requests[1:]:
+        assert request["kwargs"]["json"] == {"m": 0, "t": 1, "reflux": 0}
+        headers = request["kwargs"]["headers"]
+        assert "Authorization" not in headers
+        assert "Cookie" not in headers
+        assert request["kwargs"]["allow_redirects"] is False
+
+
+def test_live_burst_renews_uri_once_after_failure():
+    second = SIGNED.replace("private-value", "renewed")
+    api, session = client([
+        {"status": "0", "data": SIGNED},
+        {"status": "500"},
+        {"status": "0", "data": second},
+        {"data": {"es": {"pp": 7}}},
+    ])
+    assert asyncio.run(api.get_live_data("123")) == {"es": {"pp": 7}}
+    assert session.requests[3]["args"][0] == second
+
+
+def test_expired_signed_uri_renews_without_account_auth_error():
+    api, session = client([
+        {"status": "0", "data": SIGNED},
+        {"status": "401"},
+        {"status": "0", "data": SIGNED.replace("private-value", "new")},
+        {"data": {"es": {"sp": 88}}},
+    ])
+    assert asyncio.run(api.get_live_data("123")) == {"es": {"sp": 88}}
+    assert len(session.requests) == 4
+
+
+@pytest.mark.parametrize("uri", [
+    "http://eurt.hoymiles.com/rds/api/0/burst/get?sig=x",
+    "https://evil.example/rds/api/0/burst/get?sig=x",
+    "https://eurt.hoymiles.com/other?sig=x",
+    "https://eurt.hoymiles.com/rds/api/0/burst/get",
+])
+def test_live_uri_rejects_unsafe_targets_without_echoing_secret(uri):
+    api, session = client([{"status": "0", "data": uri}])
+    with pytest.raises(module.LiveDataError) as error:
+        asyncio.run(api.get_live_data("123"))
+    assert uri not in str(error.value)
+    assert len(session.requests) == 1
+
+
+def test_live_auth_denial_is_distinct():
+    api, _ = client([{"status": "401", "message": "denied", "data": None}])
+    with pytest.raises(module.LiveDataAuthError):
+        asyncio.run(api.get_live_data("123"))
+
+
+def test_live_station_permission_denial_is_not_account_auth_error():
+    api, _ = client([{"status": "3", "message": "No Permission.", "data": None}])
+    with pytest.raises(module.LiveDataError) as error:
+        asyncio.run(api.get_live_data("123"))
+    assert not isinstance(error.value, module.LiveDataAuthError)
+
+
+def test_battery_write_does_not_submit_when_read_is_denied():
+    api, session = client([{"status": "3", "message": "No Permission.", "data": None}])
+    assert asyncio.run(api.set_battery_mode("123", 1)) is False
+    assert len(session.requests) == 1
+
+
+def test_authenticated_http_401_is_not_silently_decoded():
+    class DeniedSession(FakeSession):
+        def post(self, *args, **kwargs):
+            request = super().post(*args, **kwargs)
+            request._response.status = 401
+            return request
+
+    api = HoymilesAPI(DeniedSession([{}]), "user@example.com", "secret")
+    api._token = "private-token"
+    api._token_expires_at = 9999999999
+    with pytest.raises(module.LiveDataAuthError):
+        asyncio.run(api.get_station_details("123"))
+
+
+def test_battery_writes_serialize_per_station_without_blocking_other_stations():
+    api, _ = client([])
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    entered: list[str] = []
+    settings = {
+        "readable": True,
+        "available_modes": [1],
+        "mode_settings": {1: {"reserve_soc": 10}},
+    }
+
+    async def read_settings(station_id, mode):
+        entered.append(station_id)
+        if station_id == "A" and entered.count("A") == 1:
+            first_entered.set()
+            await release_first.wait()
+        return settings, dict(settings["mode_settings"][1])
+
+    async def apply(station_id, mode, payload):
+        return True
+
+    api._get_writable_mode_settings = read_settings
+    api.apply_battery_mode_payload = apply
+
+    async def run():
+        first = asyncio.create_task(api.set_battery_mode_settings("A", 1, {"reserve_soc": 20}))
+        await asyncio.wait_for(first_entered.wait(), 1)
+        second = asyncio.create_task(api.set_battery_mode_settings("A", 1, {"reserve_soc": 30}))
+        other = asyncio.create_task(api.set_battery_mode_settings("B", 1, {"reserve_soc": 40}))
+        assert await asyncio.wait_for(other, 1) is True
+        assert entered == ["A", "B"]
+        release_first.set()
+        assert await asyncio.wait_for(first, 1) is True
+        assert await asyncio.wait_for(second, 1) is True
+        assert entered == ["A", "B", "A"]
+
+    asyncio.run(run())

--- a/tests/test_live_api.py
+++ b/tests/test_live_api.py
@@ -19,7 +19,7 @@ def client(responses):
     return api, session
 
 
-def test_live_burst_returns_raw_data_and_omits_auth_headers():
+def test_live_burst_sends_raw_authorization_without_cookies():
     payload = {"es": {"pp": 1, "gp": 2, "bp": 3, "lp": 4, "sp": 5}, "soc": 66, "flow": [], "con": 1, "t": 123, "dly": 10000}
     api, session = client([
         {"status": "0", "data": SIGNED},
@@ -33,7 +33,7 @@ def test_live_burst_returns_raw_data_and_omits_auth_headers():
     for request in session.requests[1:]:
         assert request["kwargs"]["json"] == {"m": 0, "t": 1, "reflux": 0}
         headers = request["kwargs"]["headers"]
-        assert "Authorization" not in headers
+        assert headers["Authorization"] == "private-token"
         assert "Cookie" not in headers
         assert request["kwargs"]["allow_redirects"] is False
 
@@ -48,6 +48,35 @@ def test_live_burst_renews_uri_once_after_failure():
     ])
     assert asyncio.run(api.get_live_data("123")) == {"es": {"pp": 7}}
     assert session.requests[3]["args"][0] == second
+
+
+def test_cached_live_uri_refreshes_expired_account_token():
+    api, session = client([{"data": {"es": {"pp": 7}}}])
+    api._live_uris["123"] = SIGNED
+    api._token_expires_at = 0
+
+    async def authenticate():
+        api._token = "renewed-account-token"
+        api._token_expires_at = 9999999999
+        return True
+
+    api.authenticate = authenticate
+    assert asyncio.run(api.get_live_data("123")) == {"es": {"pp": 7}}
+    assert len(session.requests) == 1
+    assert session.requests[0]["kwargs"]["headers"]["Authorization"] == "renewed-account-token"
+
+
+def test_burst_rejects_unsafe_destination_before_authentication():
+    api, session = client([])
+    api._token_expires_at = 0
+
+    async def authenticate():
+        pytest.fail("An unsafe burst destination must be rejected first")
+
+    api.authenticate = authenticate
+    with pytest.raises(module.LiveDataError):
+        asyncio.run(api._post_live_burst("https://example.com/rds/api/0/burst/get?k=secret"))
+    assert session.requests == []
 
 
 def test_expired_signed_uri_renews_without_account_auth_error():

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,24 @@
+"""Tests for entry-scoped persistence migration."""
+
+from tests.module_loader import load_integration_module
+
+
+storage = load_integration_module("storage")
+
+
+def test_migration_copies_only_owned_stations_without_aliasing():
+    legacy = {"stations": {
+        "owned": {"schedule_editor": {"modes": {"2": {"draft": [1]}}}},
+        "other": {"schedule_editor": {"modes": {"8": {"draft": [2]}}}},
+    }}
+    migrated = storage.migrate_legacy_stations(legacy, {"owned"})
+    assert set(migrated["stations"]) == {"owned"}
+    migrated["stations"]["owned"]["schedule_editor"]["modes"]["2"]["draft"].append(3)
+    assert legacy["stations"]["owned"]["schedule_editor"]["modes"]["2"]["draft"] == [1]
+    assert "other" in legacy["stations"]
+
+
+def test_entry_keys_are_distinct():
+    assert storage.entry_storage_key("hoymiles_cloud_data", "one") != storage.entry_storage_key(
+        "hoymiles_cloud_data", "two"
+    )


### PR DESCRIPTION
# 1.3.1 — Stable telemetry and reliability fixes

Promotes **1.3.1rc3** to stable. Integration code is identical to RC3 except for
the manifest version; this release does not include the experimental 1.4.0 burst
PV feature. RC tags remain unchanged.

## Changes since 1.3.0

- Correct EV charger power using authenticated burst `es.sp` telemetry instead
  of the legacy field that can mirror PV production. Disconnected/unverified
  streams are unavailable; a connected, valid zero remains zero.
- Discover missing PV channels from the declared port count on single
  microinverters, filling them through the existing module-data fallback.
- Serialize battery writes, require readable settings and readback verification,
  and retain schedule drafts if verification fails.
- Isolate station failures, bound requests, cache slower settings, and discover
  optional entities when data appears after initial setup.
- Keep schedule drafts per account, support same-account reauthentication, move
  Argon2 hashing off the event loop, and strengthen diagnostics redaction.

## Validation

- 135 standalone regression tests pass.
- Home Assistant 2026.9.2 lifecycle smoke passes with 15 simulated stations.
- RC2 hardware reports confirm charger readings in disconnected, idle and
  charging states (#64), and PV channels on HMS-800-2WB/HMS-1600-4WB (#39).
- RC3's connected-stream guard is covered by regression tests; a read-only live
  probe returned connected hybrid telemetry with a 10-second server delay.

These results are not comprehensive hardware certification. Real-device testing
of the added disconnection guard, battery write/readback, extended token expiry
and multiple-account restarts remains limited. No new hardware test is claimed
by changing the release status to stable.

## Known limitations

- #71 (15-system installer setup) and #72 (missing PV2 on another model) remain
  open and lack an exact tested candidate version/complete diagnostic evidence.
  The simulated 15-station check does not establish a fix for installer accounts.
- #69's dedicated fast PV polling is not included. The configured integration
  interval and established station PV source remain in use.
- Multi-microinverter station-channel mapping, consumer-specific burst endpoints
  and non-EU stream hosts remain outside this release's validated scope.

## Upgrade and rollback

Update to v1.3.1 through HACS (beta versions are not required), then restart Home
Assistant. For manual installation, extract the archive's
`custom_components/hoymiles_cloud` folder into the HA configuration directory.
Existing entity IDs and battery power sign conventions are unchanged.

Keep a configuration backup. To roll back, restore v1.3.0's integration files and
restart. New per-account schedule-draft edits are not copied back into legacy
shared storage; restore the backup if those edits need to be preserved.
